### PR TITLE
refactor/reflection-create-response

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionQuestionService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionQuestionService.java
@@ -6,7 +6,6 @@ import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionQuestionRe
 import com.dnd5.timoapi.domain.reflection.exception.ReflectionErrorCode;
 import com.dnd5.timoapi.domain.reflection.presentation.request.ReflectionQuestionCreateRequest;
 import com.dnd5.timoapi.domain.reflection.presentation.request.ReflectionQuestionUpdateRequest;
-import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionCreateResponse;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionQuestionDetailResponse;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionQuestionResponse;
 import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
@@ -26,15 +25,12 @@ public class ReflectionQuestionService {
 
     private final ReflectionQuestionRepository reflectionQuestionRepository;
 
-    public ReflectionCreateResponse create(ReflectionQuestionCreateRequest request) {
+    public void create(ReflectionQuestionCreateRequest request) {
         Long nextSequence = reflectionQuestionRepository.findMaxSequenceByCategory(request.category()) + 1;
 
         ReflectionQuestion questionModel = ReflectionQuestion.create(
                 nextSequence, request.category(), request.content(), request.createdBy());
-        ReflectionQuestionEntity saved = reflectionQuestionRepository.save(
-                ReflectionQuestionEntity.from(questionModel));
-
-        return new ReflectionCreateResponse(saved.getId());
+        reflectionQuestionRepository.save(ReflectionQuestionEntity.from(questionModel));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionService.java
@@ -12,6 +12,7 @@ import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository
 import com.dnd5.timoapi.domain.reflection.application.support.TodayQuestionResolver;
 import com.dnd5.timoapi.domain.reflection.exception.ReflectionErrorCode;
 import com.dnd5.timoapi.domain.reflection.presentation.request.ReflectionCreateRequest;
+import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionCreateResponse;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionDetailResponse;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionFeedbackResponse;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionQuestionDetailResponse;
@@ -38,7 +39,7 @@ public class ReflectionService {
     private final ReflectionFeedbackRepository reflectionFeedbackRepository;
     private final TodayQuestionResolver todayQuestionResolver;
 
-    public void create(ReflectionCreateRequest request) {
+    public ReflectionCreateResponse create(ReflectionCreateRequest request) {
         Long userId = SecurityUtil.getCurrentUserId();
 
         if (reflectionRepository.findByDateAndUserId(LocalDate.now(), userId).isPresent()) {
@@ -55,7 +56,8 @@ public class ReflectionService {
                 request.content(),
                 null
         );
-        reflectionRepository.save(ReflectionEntity.from(reflectionModel));
+        ReflectionEntity saved = reflectionRepository.save(ReflectionEntity.from(reflectionModel));
+        return new ReflectionCreateResponse(saved.getId());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/presentation/AdminReflectionQuestionController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/presentation/AdminReflectionQuestionController.java
@@ -3,7 +3,6 @@ package com.dnd5.timoapi.domain.reflection.presentation;
 import com.dnd5.timoapi.domain.reflection.application.service.ReflectionQuestionService;
 import com.dnd5.timoapi.domain.reflection.presentation.request.ReflectionQuestionCreateRequest;
 import com.dnd5.timoapi.domain.reflection.presentation.request.ReflectionQuestionUpdateRequest;
-import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionCreateResponse;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionQuestionResponse;
 import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import com.dnd5.timoapi.global.common.response.PageResponse;
@@ -34,8 +33,8 @@ public class AdminReflectionQuestionController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public ReflectionCreateResponse create(@Valid @RequestBody ReflectionQuestionCreateRequest request) {
-        return reflectionQuestionService.create(request);
+    public void create(@Valid @RequestBody ReflectionQuestionCreateRequest request) {
+        reflectionQuestionService.create(request);
     }
 
     @GetMapping

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/presentation/ReflectionController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/presentation/ReflectionController.java
@@ -2,6 +2,7 @@ package com.dnd5.timoapi.domain.reflection.presentation;
 
 import com.dnd5.timoapi.domain.reflection.application.service.ReflectionService;
 import com.dnd5.timoapi.domain.reflection.presentation.request.ReflectionCreateRequest;
+import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionCreateResponse;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionDetailResponse;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionQuestionDetailResponse;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionResponse;
@@ -31,8 +32,8 @@ public class ReflectionController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public void create(@Valid @RequestBody ReflectionCreateRequest request) {
-        reflectionService.create(request);
+    public ReflectionCreateResponse create(@Valid @RequestBody ReflectionCreateRequest request) {
+        return reflectionService.create(request);
     }
 
     @GetMapping("/today/question")


### PR DESCRIPTION
## What is this PR? :mag:
회고 생성 후 회고 아이디 반환

## Changes :memo:
- 유저 회고 생성 후 반환값 추가
- 기존 잘못 반환하던 사용처 삭제


---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the reflection creation API to return the created reflection ID instead of no response.
  * Modified the admin reflection question creation endpoint to no longer return a response.
  * Realigned service layer responsibilities for handling creation responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->