### PR TITLE
feat/cookie-auth

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/auth/application/service/AuthService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/auth/application/service/AuthService.java
@@ -2,15 +2,16 @@ package com.dnd5.timoapi.domain.auth.application.service;
 
 import com.dnd5.timoapi.domain.auth.domain.repository.RefreshTokenRepository;
 import com.dnd5.timoapi.domain.auth.exception.AuthErrorCode;
-import com.dnd5.timoapi.domain.auth.presentation.response.TokenResponse;
 import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
 import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
 import com.dnd5.timoapi.domain.user.exception.UserErrorCode;
 import com.dnd5.timoapi.global.exception.BusinessException;
 import com.dnd5.timoapi.global.security.context.SecurityUtil;
+import com.dnd5.timoapi.global.security.cookie.CookieUtil;
 import com.dnd5.timoapi.global.security.jwt.JwtTokenExtractor;
 import com.dnd5.timoapi.global.security.jwt.JwtTokenProvider;
 import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -22,15 +23,16 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtTokenExtractor jwtTokenExtractor;
+    private final CookieUtil cookieUtil;
 
-    public TokenResponse login(String email) {
+    public void login(String email, HttpServletResponse response) {
         UserEntity user = userRepository.findByEmailAndDeletedAtIsNull(email)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        return issueTokens(user.getId(), user.getEmail(), user.getRole().name());
+        issueTokens(user.getId(), user.getEmail(), user.getRole().name(), response);
     }
 
-    public TokenResponse reissue(String refreshToken) {
+    public void reissue(String refreshToken, HttpServletResponse response) {
         Claims claims = jwtTokenExtractor.parseClaims(refreshToken);
         Long userId = jwtTokenExtractor.getUserId(claims);
         String storedToken = refreshTokenRepository.findByUserId(userId)
@@ -43,20 +45,22 @@ public class AuthService {
         UserEntity user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        return issueTokens(user.getId(), user.getEmail(), user.getRole().name());
+        issueTokens(user.getId(), user.getEmail(), user.getRole().name(), response);
     }
 
-    public void logout() {
+    public void logout(HttpServletResponse response) {
         Long userId = SecurityUtil.getCurrentUserId();
         refreshTokenRepository.deleteByUserId(userId);
+        cookieUtil.deleteCookies(response);
     }
 
-    private TokenResponse issueTokens(Long userId, String email, String role) {
+    public void issueTokens(Long userId, String email, String role, HttpServletResponse response) {
         String accessToken = jwtTokenProvider.createAccessToken(userId, email, role);
         String refreshToken = jwtTokenProvider.createRefreshToken(userId);
 
         refreshTokenRepository.save(userId, refreshToken);
 
-        return new TokenResponse(accessToken, refreshToken);
+        cookieUtil.addAccessTokenCookie(response, accessToken);
+        cookieUtil.addRefreshTokenCookie(response, refreshToken);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/auth/infrastructure/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/dnd5/timoapi/domain/auth/infrastructure/handler/OAuth2SuccessHandler.java
@@ -1,7 +1,8 @@
 package com.dnd5.timoapi.domain.auth.infrastructure.handler;
 
+import com.dnd5.timoapi.domain.auth.application.service.AuthService;
 import com.dnd5.timoapi.domain.auth.infrastructure.config.OAuthProperties;
-import com.dnd5.timoapi.global.security.jwt.JwtTokenProvider;
+import com.dnd5.timoapi.domain.auth.infrastructure.dto.CustomOAuth2User;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -9,25 +10,25 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @RequiredArgsConstructor
 @Component
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
-    private final JwtTokenProvider tokenProvider;
+    private final AuthService authService;
     private final OAuthProperties oAuthProperties;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
             Authentication authentication) throws IOException {
-        String accessToken = tokenProvider.createAccessToken(authentication);
-        String refreshToken = tokenProvider.createRefreshToken(authentication);
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+        authService.issueTokens(
+                oAuth2User.user().id(),
+                oAuth2User.user().email(),
+                oAuth2User.user().role().name(),
+                response
+        );
 
-        String redirectUrl = UriComponentsBuilder.fromUriString(oAuthProperties.getRedirectUri())
-                .fragment("accessToken=" + accessToken + "&refreshToken=" + refreshToken)
-                .build().toUriString();
-
-        response.sendRedirect(redirectUrl);
+        response.sendRedirect(oAuthProperties.getRedirectUri());
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/auth/presentation/AuthController.java
@@ -2,12 +2,14 @@ package com.dnd5.timoapi.domain.auth.presentation;
 
 import com.dnd5.timoapi.domain.auth.application.service.AuthService;
 import com.dnd5.timoapi.domain.auth.presentation.request.LoginRequest;
-import com.dnd5.timoapi.domain.auth.presentation.request.ReissueRequest;
-import com.dnd5.timoapi.domain.auth.presentation.response.TokenResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,17 +19,20 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/test-auth/login")
-    public TokenResponse login(@Valid @RequestBody LoginRequest request) {
-        return authService.login(request.email());
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void login(@Valid @RequestBody LoginRequest request, HttpServletResponse response) {
+        authService.login(request.email(), response);
     }
 
-    @PostMapping("/test-auth/reissue")
-    public TokenResponse reissue(@Valid @RequestBody ReissueRequest request) {
-        return authService.reissue(request.refreshToken());
+    @PostMapping("/auth/reissue")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void reissue(@CookieValue("refresh_token") String refreshToken, HttpServletResponse response) {
+        authService.reissue(refreshToken, response);
     }
 
     @PostMapping("/auth/logout")
-    public void logout() {
-        authService.logout();
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void logout(HttpServletResponse response) {
+        authService.logout(response);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/auth/presentation/request/ReissueRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/auth/presentation/request/ReissueRequest.java
@@ -1,9 +1,0 @@
-package com.dnd5.timoapi.domain.auth.presentation.request;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record ReissueRequest(
-        @NotBlank
-        String refreshToken
-) {
-}

--- a/src/main/java/com/dnd5/timoapi/domain/auth/presentation/response/TokenResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/auth/presentation/response/TokenResponse.java
@@ -1,7 +1,0 @@
-package com.dnd5.timoapi.domain.auth.presentation.response;
-
-public record TokenResponse(
-        String accessToken,
-        String refreshToken
-) {
-}

--- a/src/main/java/com/dnd5/timoapi/global/security/cookie/CookieProperties.java
+++ b/src/main/java/com/dnd5/timoapi/global/security/cookie/CookieProperties.java
@@ -1,0 +1,18 @@
+package com.dnd5.timoapi.global.security.cookie;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "cookie")
+public class CookieProperties {
+
+    private boolean secure = true;
+    private String sameSite = "None";
+    private String domain = "";
+    private String path = "/";
+}

--- a/src/main/java/com/dnd5/timoapi/global/security/cookie/CookieUtil.java
+++ b/src/main/java/com/dnd5/timoapi/global/security/cookie/CookieUtil.java
@@ -1,0 +1,69 @@
+package com.dnd5.timoapi.global.security.cookie;
+
+import com.dnd5.timoapi.global.security.jwt.JwtProperties;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CookieUtil {
+
+    private static final String ACCESS_TOKEN_COOKIE = "access_token";
+    private static final String REFRESH_TOKEN_COOKIE = "refresh_token";
+
+    private final CookieProperties cookieProperties;
+    private final JwtProperties jwtProperties;
+
+    public void addAccessTokenCookie(HttpServletResponse response, String token) {
+        addCookie(response, ACCESS_TOKEN_COOKIE, token, (int) (jwtProperties.getAccessExpiration() / 1000));
+    }
+
+    public void addRefreshTokenCookie(HttpServletResponse response, String token) {
+        addCookie(response, REFRESH_TOKEN_COOKIE, token, (int) (jwtProperties.getRefreshExpiration() / 1000));
+    }
+
+    public void deleteCookies(HttpServletResponse response) {
+        addCookie(response, ACCESS_TOKEN_COOKIE, "", 0);
+        addCookie(response, REFRESH_TOKEN_COOKIE, "", 0);
+    }
+
+    public String extractAccessToken(HttpServletRequest request) {
+        return extractCookie(request, ACCESS_TOKEN_COOKIE);
+    }
+
+    public String extractRefreshToken(HttpServletRequest request) {
+        return extractCookie(request, REFRESH_TOKEN_COOKIE);
+    }
+
+    private void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(cookieProperties.isSecure())
+                .sameSite(cookieProperties.getSameSite())
+                .path(cookieProperties.getPath())
+                .maxAge(maxAge);
+
+        if (!cookieProperties.getDomain().isEmpty()) {
+            builder.domain(cookieProperties.getDomain());
+        }
+
+        response.addHeader("Set-Cookie", builder.build().toString());
+    }
+
+    private String extractCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        for (Cookie cookie : cookies) {
+            if (name.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,6 +70,12 @@ jwt:
   access-expiration: 1800000
   refresh-expiration: 604800000
 
+cookie:
+  secure: ${COOKIE_SECURE:true}
+  same-site: ${COOKIE_SAME_SITE:None}
+  domain: ${COOKIE_DOMAIN:}
+  path: ${COOKIE_PATH:/}
+
 oauth:
   redirect-uri: ${OAUTH_REDIRECT_URI:/}
 


### PR DESCRIPTION
## What is this PR? :mag:
인증을 쿠키 기반으로 변경

## Changes :memo:
기존 헤더에서 추출하던걸 쿠키 기반으로 변경 및 그에따른 환경변수화


---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication tokens now stored in secure HTTP-only cookies to enhance protection against XSS attacks.

* **Refactor**
  * Authentication endpoints updated for improved security and consistency.
  * Unified token management across login, refresh, and OAuth2 sign-in flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->