### PR TITLE
fix/create-user-question-order

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/reflection/domain/repository/UserReflectionQuestionOrderRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/domain/repository/UserReflectionQuestionOrderRepository.java
@@ -10,4 +10,6 @@ public interface UserReflectionQuestionOrderRepository extends
 
     Optional<UserReflectionQuestionOrderEntity> findByUserIdAndCategory(Long userId,
             ZtpiCategory category);
+
+    boolean existsByUserIdAndCategory(Long userId, ZtpiCategory category);
 }

--- a/src/main/java/com/dnd5/timoapi/domain/test/application/service/UserTestRecordService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/application/service/UserTestRecordService.java
@@ -2,6 +2,8 @@ package com.dnd5.timoapi.domain.test.application.service;
 
 import static com.dnd5.timoapi.global.security.context.SecurityUtil.getCurrentUserId;
 
+import com.dnd5.timoapi.domain.reflection.domain.entity.UserReflectionQuestionOrderEntity;
+import com.dnd5.timoapi.domain.reflection.domain.repository.UserReflectionQuestionOrderRepository;
 import com.dnd5.timoapi.domain.test.domain.entity.TestEntity;
 import com.dnd5.timoapi.domain.test.domain.entity.TestQuestionEntity;
 import com.dnd5.timoapi.domain.test.domain.entity.UserTestRecordEntity;
@@ -47,6 +49,7 @@ public class UserTestRecordService {
     private final UserTestResultRepository userTestResultRepository;
 
     private final UserTestRecordRepository userTestRecordRepository;
+    private final UserReflectionQuestionOrderRepository userReflectionQuestionOrderRepository;
 
     public UserTestRecordCreateResponse create(UserTestRecordCreateRequest request) {
         Long userId = getCurrentUserId();
@@ -85,6 +88,7 @@ public class UserTestRecordService {
         createUserTestResults(userTestRecordEntity, userTestResponseEntityList);
 
         userTestRecordEntity.complete();
+        createUserReflectionQuestionOrders(userTestRecordEntity.getUser().getId());
 
         UserEntity userEntity = userTestRecordEntity.getUser();
         if (!userEntity.getIsOnboarded()) {
@@ -123,6 +127,16 @@ public class UserTestRecordService {
     private UserTestRecordEntity getUserTestRecordEntity(Long testRecordId) {
         return userTestRecordRepository.findById(testRecordId)
                 .orElseThrow(() -> new BusinessException(UserTestRecordErrorCode.USER_TEST_RECORD_NOT_FOUND));
+    }
+
+    private void createUserReflectionQuestionOrders(Long userId) {
+        for (ZtpiCategory category : ZtpiCategory.values()) {
+            if (!userReflectionQuestionOrderRepository.existsByUserIdAndCategory(userId, category)) {
+                userReflectionQuestionOrderRepository.save(
+                        new UserReflectionQuestionOrderEntity(userId, category, 1L)
+                );
+            }
+        }
     }
 
     private void validateAllQuestionsAnswered(List<TestQuestionEntity> testQuestionEntityList, List<UserTestResponseEntity> userTestResponseEntityList) {


### PR DESCRIPTION
## What is this PR? :mag:
QuestionOrder 테이블 생성하는 로직을 추가

## Changes :memo:
첫 테스트 완료 시 유저의 질문 순서 상태를 관리하는 테이블 생성 로직을 추가했습니다

---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reflection question orders are now automatically initialized for all available categories upon test completion, ensuring they are immediately ready for user review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->