### PR TITLE
feat/#22-reflection-feedback-async

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackAsyncService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackAsyncService.java
@@ -1,0 +1,110 @@
+package com.dnd5.timoapi.domain.reflection.application.service;
+
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionFeedbackEntity;
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionQuestionEntity;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionFeedbackRepository;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionQuestionRepository;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
+import com.dnd5.timoapi.domain.reflection.exception.ReflectionErrorCode;
+import com.dnd5.timoapi.domain.reflection.infrastructure.ai.FeedbackGenerator;
+import com.dnd5.timoapi.domain.reflection.infrastructure.ai.FeedbackResult;
+import com.dnd5.timoapi.domain.reflection.infrastructure.sse.FeedbackSseEmitterRepository;
+import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionFeedbackDetailResponse;
+import com.dnd5.timoapi.global.exception.BusinessException;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReflectionFeedbackAsyncService {
+
+    private static final int MIN_FEEDBACK_SCORE = 0;
+    private static final int MAX_FEEDBACK_SCORE = 100;
+
+    private final ReflectionFeedbackRepository reflectionFeedbackRepository;
+    private final ReflectionRepository reflectionRepository;
+    private final ReflectionQuestionRepository reflectionQuestionRepository;
+    private final FeedbackGenerator feedbackGenerator;
+    private final FeedbackSseEmitterRepository sseEmitterRepository;
+
+    @Async
+    @Transactional
+    public void execute(Long reflectionId, Long feedbackId) {
+        ReflectionFeedbackEntity feedbackEntity = reflectionFeedbackRepository.findById(feedbackId)
+                .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_FEEDBACK_NOT_FOUND));
+
+        feedbackEntity.restartProcessing();
+
+        ReflectionEntity reflectionEntity = reflectionRepository.findById(reflectionId)
+                .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_NOT_FOUND));
+
+        ReflectionQuestionEntity questionEntity = reflectionQuestionRepository
+                .findById(reflectionEntity.getQuestionId())
+                .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_QUESTION_NOT_FOUND));
+
+        String failureReason = null;
+        try {
+            FeedbackResult result = feedbackGenerator.execute(
+                    questionEntity.getCategory(),
+                    questionEntity.getContent(),
+                    reflectionEntity.getAnswerText()
+            );
+            validateScore(result.score());
+            feedbackEntity.complete(result.score(), result.content());
+        } catch (BusinessException e) {
+            log.error("Feedback generation failed with business error for reflectionId={}", reflectionId, e);
+            feedbackEntity.fail();
+        } catch (Exception e) {
+            log.error("Feedback generation failed for reflectionId={}", reflectionId, e);
+            feedbackEntity.fail();
+            failureReason = extractFailureReason(e);
+        }
+
+        sendSseEvent(reflectionId, feedbackEntity, failureReason);
+    }
+
+    private void sendSseEvent(Long reflectionId, ReflectionFeedbackEntity feedbackEntity, String failureReason) {
+        sseEmitterRepository.get(reflectionId).ifPresent(emitter -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("feedback")
+                        .data(ReflectionFeedbackDetailResponse.from(feedbackEntity.toModel(), failureReason)));
+                emitter.complete();
+            } catch (IOException e) {
+                log.error("Failed to send SSE event for reflectionId={}", reflectionId, e);
+                emitter.completeWithError(e);
+            } finally {
+                sseEmitterRepository.remove(reflectionId);
+            }
+        });
+    }
+
+    private void validateScore(int score) {
+        if (score < MIN_FEEDBACK_SCORE || score > MAX_FEEDBACK_SCORE) {
+            throw new BusinessException(
+                    ReflectionErrorCode.REFLECTION_FEEDBACK_SCORE_OUT_OF_RANGE,
+                    score,
+                    MIN_FEEDBACK_SCORE,
+                    MAX_FEEDBACK_SCORE
+            );
+        }
+    }
+
+    private String extractFailureReason(Exception e) {
+        Throwable root = e;
+        while (root.getCause() != null) {
+            root = root.getCause();
+        }
+        if (root.getMessage() != null && !root.getMessage().isBlank()) {
+            return root.getMessage();
+        }
+        return "피드백 생성 중 알 수 없는 오류가 발생했습니다.";
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackService.java
@@ -2,15 +2,11 @@ package com.dnd5.timoapi.domain.reflection.application.service;
 
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionFeedbackEntity;
-import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionQuestionEntity;
 import com.dnd5.timoapi.domain.reflection.domain.model.ReflectionFeedback;
 import com.dnd5.timoapi.domain.reflection.domain.model.enums.FeedbackStatus;
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionFeedbackRepository;
-import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionQuestionRepository;
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
 import com.dnd5.timoapi.domain.reflection.exception.ReflectionErrorCode;
-import com.dnd5.timoapi.domain.reflection.infrastructure.ai.FeedbackGenerator;
-import com.dnd5.timoapi.domain.reflection.infrastructure.ai.FeedbackResult;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionFeedbackDetailResponse;
 import com.dnd5.timoapi.global.exception.BusinessException;
 import com.dnd5.timoapi.global.security.context.SecurityUtil;
@@ -25,58 +21,32 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class ReflectionFeedbackService {
 
-    private static final int MIN_FEEDBACK_SCORE = 0;
-    private static final int MAX_FEEDBACK_SCORE = 100;
-
     private final ReflectionFeedbackRepository reflectionFeedbackRepository;
     private final ReflectionRepository reflectionRepository;
-    private final FeedbackGenerator feedbackGenerator;
-    private final ReflectionQuestionRepository reflectionQuestionRepository;
+    private final ReflectionFeedbackAsyncService reflectionFeedbackAsyncService;
 
     public ReflectionFeedbackDetailResponse create(Long reflectionId) {
         Long currentUserId = SecurityUtil.getCurrentUserId();
-        String failureReason = null;
+
         ReflectionEntity reflectionEntity = reflectionRepository.findById(reflectionId)
                 .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_NOT_FOUND));
         validateOwnership(reflectionEntity, currentUserId);
 
         ReflectionFeedbackEntity feedbackEntity = reflectionFeedbackRepository.findByReflectionId(reflectionId)
-                .map(existingFeedback -> prepareFeedbackForRegeneration(reflectionId, existingFeedback))
+                .map(existing -> {
+                    if (existing.getStatus() != FeedbackStatus.FAILED) {
+                        throw new BusinessException(ReflectionErrorCode.REFLECTION_FEEDBACK_ALREADY_EXISTS);
+                    }
+                    log.info("Retrying failed reflection feedback generation for reflectionId={}", reflectionId);
+                    return existing;
+                })
                 .orElseGet(() -> reflectionFeedbackRepository.save(ReflectionFeedbackEntity.from(
-                        new ReflectionFeedback(
-                                null,
-                                reflectionEntity.getId(),
-                                0,
-                                null,
-                                FeedbackStatus.PROCESSING,
-                                null
-                        )
+                        new ReflectionFeedback(null, reflectionId, 0, null, FeedbackStatus.PENDING, null)
                 )));
 
-        ReflectionQuestionEntity reflectionQuestionEntity =
-                reflectionQuestionRepository.findById(reflectionEntity.getQuestionId())
-                        .orElseThrow(() -> new BusinessException(
-                                ReflectionErrorCode.REFLECTION_QUESTION_NOT_FOUND));
+        reflectionFeedbackAsyncService.execute(reflectionId, feedbackEntity.getId());
 
-        try {
-            FeedbackResult feedbackResult = feedbackGenerator.execute(
-                    reflectionQuestionEntity.getCategory(),
-                    reflectionQuestionEntity.getContent(),
-                    reflectionEntity.getAnswerText()
-            );
-            validateScore(feedbackResult.score());
-            feedbackEntity.complete(feedbackResult.score(), feedbackResult.content());
-        } catch (BusinessException e) {
-            log.error("Feedback generation failed with business error for reflectionId={}", reflectionId, e);
-            feedbackEntity.fail();
-            throw e;
-        } catch (Exception e) {
-            log.error("Feedback generation failed for reflectionId={}", reflectionId, e);
-            feedbackEntity.fail();
-            failureReason = extractFailureReason(e);
-        }
-
-        return ReflectionFeedbackDetailResponse.from(feedbackEntity.toModel(), failureReason);
+        return ReflectionFeedbackDetailResponse.from(feedbackEntity.toModel());
     }
 
     private void validateOwnership(ReflectionEntity reflectionEntity, Long currentUserId) {
@@ -88,40 +58,5 @@ public class ReflectionFeedbackService {
                     currentUserId
             );
         }
-    }
-
-    private ReflectionFeedbackEntity prepareFeedbackForRegeneration(
-            Long reflectionId,
-            ReflectionFeedbackEntity existingFeedback
-    ) {
-        if (existingFeedback.getStatus() != FeedbackStatus.FAILED) {
-            throw new BusinessException(ReflectionErrorCode.REFLECTION_FEEDBACK_ALREADY_EXISTS);
-        }
-
-        log.info("Retrying failed reflection feedback generation for reflectionId={}", reflectionId);
-        existingFeedback.restartProcessing();
-        return existingFeedback;
-    }
-
-    private void validateScore(int score) {
-        if (score < MIN_FEEDBACK_SCORE || score > MAX_FEEDBACK_SCORE) {
-            throw new BusinessException(
-                    ReflectionErrorCode.REFLECTION_FEEDBACK_SCORE_OUT_OF_RANGE,
-                    score,
-                    MIN_FEEDBACK_SCORE,
-                    MAX_FEEDBACK_SCORE
-            );
-        }
-    }
-
-    private String extractFailureReason(Exception e) {
-        Throwable root = e;
-        while (root.getCause() != null) {
-            root = root.getCause();
-        }
-        if (root.getMessage() != null && !root.getMessage().isBlank()) {
-            return root.getMessage();
-        }
-        return "피드백 생성 중 알 수 없는 오류가 발생했습니다.";
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/infrastructure/sse/FeedbackSseEmitterRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/infrastructure/sse/FeedbackSseEmitterRepository.java
@@ -1,0 +1,24 @@
+package com.dnd5.timoapi.domain.reflection.infrastructure.sse;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Component
+public class FeedbackSseEmitterRepository {
+
+    private final ConcurrentHashMap<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public void save(Long reflectionId, SseEmitter emitter) {
+        emitters.put(reflectionId, emitter);
+    }
+
+    public Optional<SseEmitter> get(Long reflectionId) {
+        return Optional.ofNullable(emitters.get(reflectionId));
+    }
+
+    public void remove(Long reflectionId) {
+        emitters.remove(reflectionId);
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/presentation/ReflectionFeedbackController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/presentation/ReflectionFeedbackController.java
@@ -1,17 +1,28 @@
 package com.dnd5.timoapi.domain.reflection.presentation;
 
 import com.dnd5.timoapi.domain.reflection.application.service.ReflectionFeedbackService;
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionFeedbackEntity;
+import com.dnd5.timoapi.domain.reflection.domain.model.enums.FeedbackStatus;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionFeedbackRepository;
+import com.dnd5.timoapi.domain.reflection.infrastructure.sse.FeedbackSseEmitterRepository;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionFeedbackDetailResponse;
 import jakarta.validation.constraints.Positive;
+import java.io.IOException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+@Slf4j
 @RestController
 @RequestMapping("/reflections/{reflectionId}/feedback")
 @RequiredArgsConstructor
@@ -19,10 +30,41 @@ import org.springframework.web.bind.annotation.RestController;
 public class ReflectionFeedbackController {
 
     private final ReflectionFeedbackService reflectionFeedbackService;
+    private final ReflectionFeedbackRepository reflectionFeedbackRepository;
+    private final FeedbackSseEmitterRepository sseEmitterRepository;
 
     @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
+    @ResponseStatus(HttpStatus.ACCEPTED)
     public ReflectionFeedbackDetailResponse create(@Positive @PathVariable Long reflectionId) {
         return reflectionFeedbackService.create(reflectionId);
+    }
+
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@Positive @PathVariable Long reflectionId) {
+        Optional<ReflectionFeedbackEntity> existing = reflectionFeedbackRepository.findByReflectionId(reflectionId);
+
+        if (existing.isPresent()) {
+            FeedbackStatus status = existing.get().getStatus();
+            if (status == FeedbackStatus.COMPLETED || status == FeedbackStatus.FAILED) {
+                SseEmitter emitter = new SseEmitter(0L);
+                try {
+                    emitter.send(SseEmitter.event()
+                            .name("feedback")
+                            .data(ReflectionFeedbackDetailResponse.from(existing.get().toModel())));
+                    emitter.complete();
+                } catch (IOException e) {
+                    log.error("Failed to send immediate SSE event for reflectionId={}", reflectionId, e);
+                    emitter.completeWithError(e);
+                }
+                return emitter;
+            }
+        }
+
+        SseEmitter emitter = new SseEmitter(60_000L);
+        sseEmitterRepository.save(reflectionId, emitter);
+        emitter.onCompletion(() -> sseEmitterRepository.remove(reflectionId));
+        emitter.onTimeout(() -> sseEmitterRepository.remove(reflectionId));
+        emitter.onError(e -> sseEmitterRepository.remove(reflectionId));
+        return emitter;
     }
 }

--- a/src/test/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackAsyncServiceTest.java
+++ b/src/test/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackAsyncServiceTest.java
@@ -1,0 +1,140 @@
+package com.dnd5.timoapi.domain.reflection.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionFeedbackEntity;
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionQuestionEntity;
+import com.dnd5.timoapi.domain.reflection.domain.model.enums.FeedbackStatus;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionFeedbackRepository;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionQuestionRepository;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
+import com.dnd5.timoapi.domain.reflection.exception.ReflectionErrorCode;
+import com.dnd5.timoapi.domain.reflection.infrastructure.ai.FeedbackGenerator;
+import com.dnd5.timoapi.domain.reflection.infrastructure.ai.FeedbackResult;
+import com.dnd5.timoapi.domain.reflection.infrastructure.sse.FeedbackSseEmitterRepository;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+import com.dnd5.timoapi.global.exception.BusinessException;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReflectionFeedbackAsyncServiceTest {
+
+    @InjectMocks
+    private ReflectionFeedbackAsyncService reflectionFeedbackAsyncService;
+
+    @Mock
+    private ReflectionFeedbackRepository reflectionFeedbackRepository;
+
+    @Mock
+    private ReflectionRepository reflectionRepository;
+
+    @Mock
+    private ReflectionQuestionRepository reflectionQuestionRepository;
+
+    @Mock
+    private FeedbackGenerator feedbackGenerator;
+
+    @Mock
+    private FeedbackSseEmitterRepository sseEmitterRepository;
+
+    @Test
+    void execute_성공시_COMPLETED_처리() {
+        Long reflectionId = 10L;
+        Long feedbackId = 1L;
+        Long questionId = 3L;
+        String answerText = "회고 내용";
+
+        ReflectionFeedbackEntity feedbackEntity = spy(
+                new ReflectionFeedbackEntity(reflectionId, 0, null, FeedbackStatus.PENDING)
+        );
+        when(reflectionFeedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedbackEntity));
+
+        ReflectionEntity reflectionEntity = new ReflectionEntity(1L, questionId, LocalDate.now(), answerText);
+        when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflectionEntity));
+
+        ReflectionQuestionEntity questionEntity = new ReflectionQuestionEntity(
+                1L, ZtpiCategory.FUTURE, "질문", "system"
+        );
+        when(reflectionQuestionRepository.findById(questionId)).thenReturn(Optional.of(questionEntity));
+        when(feedbackGenerator.execute(ZtpiCategory.FUTURE, "질문", answerText))
+                .thenReturn(new FeedbackResult(80, "피드백"));
+        when(sseEmitterRepository.get(reflectionId)).thenReturn(Optional.empty());
+
+        reflectionFeedbackAsyncService.execute(reflectionId, feedbackId);
+
+        verify(feedbackEntity).restartProcessing();
+        verify(feedbackEntity).complete(80, "피드백");
+        verify(feedbackEntity, never()).fail();
+    }
+
+    @Test
+    void execute_score_범위_초과시_FAILED_처리() {
+        Long reflectionId = 10L;
+        Long feedbackId = 1L;
+        Long questionId = 3L;
+        String answerText = "회고 내용";
+
+        ReflectionFeedbackEntity feedbackEntity = spy(
+                new ReflectionFeedbackEntity(reflectionId, 0, null, FeedbackStatus.PENDING)
+        );
+        when(reflectionFeedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedbackEntity));
+
+        ReflectionEntity reflectionEntity = new ReflectionEntity(1L, questionId, LocalDate.now(), answerText);
+        when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflectionEntity));
+
+        ReflectionQuestionEntity questionEntity = new ReflectionQuestionEntity(
+                1L, ZtpiCategory.FUTURE, "질문", "system"
+        );
+        when(reflectionQuestionRepository.findById(questionId)).thenReturn(Optional.of(questionEntity));
+        when(feedbackGenerator.execute(ZtpiCategory.FUTURE, "질문", answerText))
+                .thenReturn(new FeedbackResult(200, "피드백"));
+        when(sseEmitterRepository.get(reflectionId)).thenReturn(Optional.empty());
+
+        reflectionFeedbackAsyncService.execute(reflectionId, feedbackId);
+
+        verify(feedbackEntity).fail();
+        verify(feedbackEntity, never()).complete(anyInt(), any(String.class));
+    }
+
+    @Test
+    void execute_예외_발생시_FAILED_처리() {
+        Long reflectionId = 10L;
+        Long feedbackId = 1L;
+        Long questionId = 3L;
+        String answerText = "회고 내용";
+
+        ReflectionFeedbackEntity feedbackEntity = spy(
+                new ReflectionFeedbackEntity(reflectionId, 0, null, FeedbackStatus.PENDING)
+        );
+        when(reflectionFeedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedbackEntity));
+
+        ReflectionEntity reflectionEntity = new ReflectionEntity(1L, questionId, LocalDate.now(), answerText);
+        when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflectionEntity));
+
+        ReflectionQuestionEntity questionEntity = new ReflectionQuestionEntity(
+                1L, ZtpiCategory.FUTURE, "질문", "system"
+        );
+        when(reflectionQuestionRepository.findById(questionId)).thenReturn(Optional.of(questionEntity));
+        when(feedbackGenerator.execute(ZtpiCategory.FUTURE, "질문", answerText))
+                .thenThrow(new RuntimeException("Gemini timeout"));
+        when(sseEmitterRepository.get(reflectionId)).thenReturn(Optional.empty());
+
+        reflectionFeedbackAsyncService.execute(reflectionId, feedbackId);
+
+        verify(feedbackEntity).fail();
+        verify(feedbackEntity, never()).complete(anyInt(), any(String.class));
+    }
+}

--- a/src/test/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackServiceTest.java
+++ b/src/test/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackServiceTest.java
@@ -3,7 +3,6 @@ package com.dnd5.timoapi.domain.reflection.application.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -11,16 +10,11 @@ import static org.mockito.Mockito.when;
 
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionFeedbackEntity;
-import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionQuestionEntity;
 import com.dnd5.timoapi.domain.reflection.domain.model.enums.FeedbackStatus;
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionFeedbackRepository;
-import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionQuestionRepository;
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
 import com.dnd5.timoapi.domain.reflection.exception.ReflectionErrorCode;
-import com.dnd5.timoapi.domain.reflection.infrastructure.ai.FeedbackGenerator;
-import com.dnd5.timoapi.domain.reflection.infrastructure.ai.FeedbackResult;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionFeedbackDetailResponse;
-import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import com.dnd5.timoapi.global.exception.BusinessException;
 import com.dnd5.timoapi.global.security.context.SecurityUtil;
 import java.time.LocalDate;
@@ -46,10 +40,7 @@ class ReflectionFeedbackServiceTest {
     private ReflectionRepository reflectionRepository;
 
     @Mock
-    private FeedbackGenerator feedbackGenerator;
-
-    @Mock
-    private ReflectionQuestionRepository reflectionQuestionRepository;
+    private ReflectionFeedbackAsyncService reflectionFeedbackAsyncService;
 
     @Test
     void create_다른_유저_회고면_403_예외() {
@@ -76,9 +67,8 @@ class ReflectionFeedbackServiceTest {
     void create_FAILED_기존_피드백은_재생성_허용() {
         Long reflectionId = 10L;
         Long questionId = 3L;
-        String answerText = "회고 내용";
 
-        ReflectionEntity reflectionEntity = new ReflectionEntity(1L, questionId, LocalDate.now(), answerText);
+        ReflectionEntity reflectionEntity = new ReflectionEntity(1L, questionId, LocalDate.now(), "회고 내용");
         when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflectionEntity));
 
         ReflectionFeedbackEntity failedFeedback = spy(
@@ -87,49 +77,29 @@ class ReflectionFeedbackServiceTest {
         when(reflectionFeedbackRepository.findByReflectionId(reflectionId))
                 .thenReturn(Optional.of(failedFeedback));
 
-        ReflectionQuestionEntity questionEntity = new ReflectionQuestionEntity(
-                1L, ZtpiCategory.FUTURE, "질문", "system"
-        );
-        when(reflectionQuestionRepository.findById(questionId)).thenReturn(Optional.of(questionEntity));
-        when(feedbackGenerator.execute(ZtpiCategory.FUTURE, "질문", answerText))
-                .thenReturn(new FeedbackResult(80, "피드백"));
-
         try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
             mocked.when(SecurityUtil::getCurrentUserId).thenReturn(1L);
 
             ReflectionFeedbackDetailResponse response = reflectionFeedbackService.create(reflectionId);
 
-            assertThat(response.score()).isEqualTo(80);
-            assertThat(response.status()).isEqualTo(FeedbackStatus.COMPLETED);
-            assertThat(response.failureReason()).isNull();
+            assertThat(response.status()).isEqualTo(FeedbackStatus.FAILED);
         }
 
-        verify(failedFeedback).restartProcessing();
-        verify(failedFeedback).complete(80, "피드백");
         verify(reflectionFeedbackRepository, never()).save(any());
     }
 
     @Test
-    void create_score_범위_초과시_예외_반환() {
+    void create_COMPLETED_피드백은_재생성_불가() {
         Long reflectionId = 10L;
-        Long questionId = 3L;
-        String answerText = "회고 내용";
 
-        ReflectionEntity reflectionEntity = new ReflectionEntity(1L, questionId, LocalDate.now(), answerText);
+        ReflectionEntity reflectionEntity = new ReflectionEntity(1L, 3L, LocalDate.now(), "회고 내용");
         when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflectionEntity));
 
-        ReflectionFeedbackEntity processingFeedback = spy(
-                new ReflectionFeedbackEntity(reflectionId, 0, null, FeedbackStatus.PROCESSING)
+        ReflectionFeedbackEntity completedFeedback = new ReflectionFeedbackEntity(
+                reflectionId, 80, "피드백", FeedbackStatus.COMPLETED
         );
-        when(reflectionFeedbackRepository.findByReflectionId(reflectionId)).thenReturn(Optional.empty());
-        when(reflectionFeedbackRepository.save(any(ReflectionFeedbackEntity.class))).thenReturn(processingFeedback);
-
-        ReflectionQuestionEntity questionEntity = new ReflectionQuestionEntity(
-                1L, ZtpiCategory.FUTURE, "질문", "system"
-        );
-        when(reflectionQuestionRepository.findById(questionId)).thenReturn(Optional.of(questionEntity));
-        when(feedbackGenerator.execute(ZtpiCategory.FUTURE, "질문", answerText))
-                .thenReturn(new FeedbackResult(200, "피드백"));
+        when(reflectionFeedbackRepository.findByReflectionId(reflectionId))
+                .thenReturn(Optional.of(completedFeedback));
 
         try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
             mocked.when(SecurityUtil::getCurrentUserId).thenReturn(1L);
@@ -139,44 +109,28 @@ class ReflectionFeedbackServiceTest {
                     .satisfies(exception -> {
                         BusinessException businessException = (BusinessException) exception;
                         assertThat(businessException.getErrorCode())
-                                .isEqualTo(ReflectionErrorCode.REFLECTION_FEEDBACK_SCORE_OUT_OF_RANGE);
+                                .isEqualTo(ReflectionErrorCode.REFLECTION_FEEDBACK_ALREADY_EXISTS);
                     });
         }
-
-        verify(processingFeedback).fail();
-        verify(processingFeedback, never()).complete(anyInt(), any(String.class));
     }
 
     @Test
-    void create_예외로_FAILED_처리되면_실패원인_반환() {
+    void create_신규_피드백은_PENDING_상태로_즉시_반환() {
         Long reflectionId = 10L;
-        Long questionId = 3L;
-        String answerText = "회고 내용";
 
-        ReflectionEntity reflectionEntity = new ReflectionEntity(1L, questionId, LocalDate.now(), answerText);
+        ReflectionEntity reflectionEntity = new ReflectionEntity(1L, 3L, LocalDate.now(), "회고 내용");
         when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflectionEntity));
-
-        ReflectionFeedbackEntity processingFeedback = spy(
-                new ReflectionFeedbackEntity(reflectionId, 0, null, FeedbackStatus.PROCESSING)
-        );
         when(reflectionFeedbackRepository.findByReflectionId(reflectionId)).thenReturn(Optional.empty());
-        when(reflectionFeedbackRepository.save(any(ReflectionFeedbackEntity.class))).thenReturn(processingFeedback);
 
-        ReflectionQuestionEntity questionEntity = new ReflectionQuestionEntity(
-                1L, ZtpiCategory.FUTURE, "질문", "system"
-        );
-        when(reflectionQuestionRepository.findById(questionId)).thenReturn(Optional.of(questionEntity));
-        when(feedbackGenerator.execute(ZtpiCategory.FUTURE, "질문", answerText))
-                .thenThrow(new RuntimeException("Gemini timeout"));
+        ReflectionFeedbackEntity pendingFeedback = new ReflectionFeedbackEntity(reflectionId, 0, null, FeedbackStatus.PENDING);
+        when(reflectionFeedbackRepository.save(any(ReflectionFeedbackEntity.class))).thenReturn(pendingFeedback);
 
         try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
             mocked.when(SecurityUtil::getCurrentUserId).thenReturn(1L);
 
             ReflectionFeedbackDetailResponse response = reflectionFeedbackService.create(reflectionId);
-            assertThat(response.status()).isEqualTo(FeedbackStatus.FAILED);
-            assertThat(response.failureReason()).isEqualTo("Gemini timeout");
-        }
 
-        verify(processingFeedback).fail();
+            assertThat(response.status()).isEqualTo(FeedbackStatus.PENDING);
+        }
     }
 }


### PR DESCRIPTION
## What is this PR? :mag:
close #22 

피드백 API - 프론트엔드 연동 가이드                    

 전체 흐름

 [1] POST /reflections/{id}/feedback
         → 202 Accepted
         → { status: "PENDING", ... } 즉시 반환

 [2] GET /reflections/{id}/feedback/subscribe  (SSE 연결)
         → 연결 유지 중...
         → Gemini 완료 시 "feedback" 이벤트 수신
         → { status: "COMPLETED" or "FAILED", score, content, ... }

 ---
 상세 시나리오

 정상 케이스

 프론트                          서버
   |                              |
   |── POST /feedback ──────────>|
   |<── 202 { status: PENDING } ─|  ← 즉시 응답 (로딩 UI 표시)
   |                              |
   |── GET /subscribe ───────────>|  ← SSE 연결
   |                              |  (Gemini 처리 중...)
   |<── event: feedback ──────── |  ← 완료 이벤트 수신
   |   { status: COMPLETED,       |
   |     score: 80,               |
   |     content: "..." }         |
   |── 연결 종료 ─────────────── |

 이미 완료된 경우 (재접속)

 프론트                          서버
   |── GET /subscribe ───────────>|
   |<── event: feedback ─────── |  ← 즉시 완료 이벤트 전송
   |   { status: COMPLETED, ... } |
   |── 연결 종료 ─────────────── |

 실패 케이스

   |<── event: feedback ─────── |
   |   { status: "FAILED",        |
   |     failureReason: "..." }   |
   → 재시도 버튼 표시

 ---
 API 스펙

 POST /reflections/{reflectionId}/feedback

 - 성공: 202 Accepted
 - 이미 진행 중/완료: 409 Conflict
 - 권한 없음: 403 Forbidden

 응답 body:
 {
   "id": 1,
   "reflectionId": 10,
   "score": 0,
   "content": null,
   "status": "PENDING",
   "createdAt": "...",
   "failureReason": null
 }

 ---
 GET /reflections/{reflectionId}/feedback/subscribe

 - Content-Type: text/event-stream
 - 타임아웃: 60초 (연결 후 Gemini 응답이 없으면 자동 종료)

 수신 이벤트:
 event: feedback
 data: {"id":1,"reflectionId":10,"score":80,"content":"피드백 내용","status":"COMPLETED","createdAt":"...","failureReason":null}

 ---
 프론트엔드 구현 가이드

 async function requestFeedback(reflectionId: number) {
   // 1. 피드백 생성 요청
   const res = await fetch(`/reflections/${reflectionId}/feedback`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}` },
   });

   if (!res.ok) {
     if (res.status === 409) {
       // 이미 피드백이 존재 → subscribe로 결과 확인
     } else {
       throw new Error('피드백 요청 실패');
     }
   }

   // 2. SSE 구독 (결과 대기)
   subscribeToFeedback(reflectionId);
 }

 function subscribeToFeedback(reflectionId: number) {
   const url = `/reflections/${reflectionId}/feedback/subscribe`;
   const eventSource = new EventSource(url, {
     // 인증이 필요한 경우 fetch + ReadableStream 방식 사용 권장
   });

   eventSource.addEventListener('feedback', (e) => {
     const feedback = JSON.parse(e.data);
     eventSource.close();

     if (feedback.status === 'COMPLETED') {
       // 피드백 표시
     } else if (feedback.status === 'FAILED') {
       // 실패 처리 (재시도 버튼 등)
     }
   });

   eventSource.onerror = () => {
     eventSource.close();
     // 에러 처리
   };
 }

 주의: EventSource는 기본적으로 Authorization 헤더를 지원하지 않는다.
 JWT 인증이 필요하면 fetch + ReadableStream 또는 쿼리 파라미터로 토큰 전달 방식 검토 필요.

 ---
 FeedbackStatus 정의

 ┌────────────┬────────────────────┬────────────────────┐
 │    상태    │        의미        │    프론트 처리     │
 ├────────────┼────────────────────┼────────────────────┤
 │ PENDING    │ 요청 접수, 대기 중 │ 로딩 표시          │
 ├────────────┼────────────────────┼────────────────────┤
 │ PROCESSING │ Gemini 처리 중     │ 로딩 표시          │
 ├────────────┼────────────────────┼────────────────────┤
 │ COMPLETED  │ 완료               │ 피드백 표시        │
 ├────────────┼────────────────────┼────────────────────┤
 │ FAILED     │ 실패               │ 오류 + 재시도 버튼 │
 └────────────┴────────────────────┴────────────────────┘

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feedback generation now processes asynchronously in the background
  * Added real-time feedback completion notifications via server-sent events

* **Changes**
  * Feedback creation endpoint now returns 202 Accepted status instead of 201 Created

<!-- end of auto-generated comment: release notes by coderabbit.ai -->