### PR TITLE
feat/#73-users-me-add-response-provider

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/user/presentation/response/UserResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/presentation/response/UserResponse.java
@@ -1,12 +1,14 @@
 package com.dnd5.timoapi.domain.user.presentation.response;
 
 import com.dnd5.timoapi.domain.user.domain.model.User;
+import com.dnd5.timoapi.domain.user.domain.model.enums.OAuthProvider;
 import java.time.LocalDateTime;
 
 public record UserResponse(
         Long id,
         String name,
         String email,
+        OAuthProvider provider,
         Boolean isOnboarded,
         Integer streakDays,
         LocalDateTime createdAt
@@ -16,6 +18,7 @@ public record UserResponse(
                 model.id(),
                 model.nickname(),
                 model.email(),
+                model.provider(),
                 model.isOnboarded(),
                 model.streakDays(),
                 model.createdAt()


### PR DESCRIPTION
## What is this PR? :mag:
73번 이슈 해결

## Changes :memo:
내 정보 조회 API 응답에 provider 추가하여 조회 가능하도록 변경

## Screenshot  :camera:
<img width="306" height="173" alt="스크린샷 2026-02-24 오후 7 21 13" src="https://github.com/user-attachments/assets/67c5a0a9-ab09-4457-9f48-655b6a8d561d" />

---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User account information now displays which OAuth authentication provider was used, helping users identify their login method at a glance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->