### PR TITLE
fix/streak-count

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionService.java
@@ -67,7 +67,9 @@ public class ReflectionService {
 
         UserEntity userEntity = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-        userEntity.incrementStreakDays();
+
+        boolean wroteYesterday = isWroteYesterday(userId);
+        userEntity.updateStreak(wroteYesterday);
 
         return new ReflectionCreateResponse(saved.getId());
     }
@@ -208,6 +210,12 @@ public class ReflectionService {
                     currentUserId
             );
         }
+    }
+
+    private boolean isWroteYesterday(Long userId) {
+        return reflectionRepository
+                .findByDateAndUserId(LocalDate.now().minusDays(1), userId)
+                .isPresent();
     }
 
     private ReflectionQuestionEntity findTodayQuestionEntity(Long userId) {

--- a/src/main/java/com/dnd5/timoapi/domain/user/domain/entity/UserEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/domain/entity/UserEntity.java
@@ -69,8 +69,12 @@ public class UserEntity extends BaseEntity {
         this.isOnboarded = true;
     }
 
-    public void incrementStreakDays() {
-        this.streakDays += 1;
+    public void updateStreak(boolean isConsecutive) {
+        if (isConsecutive) {
+            this.streakDays += 1;
+        } else {
+            this.streakDays = 1;
+        }
     }
 
     public void resetStreakDays() {


### PR DESCRIPTION
## What is this PR? :mag:
연속 기록이 아닌데, 연속기록이라고 저장되는 오류 해결

## Changes :memo:
- 기존: 연속을 확인하지 않고 회고 작성시 무조건 1 상승하는 경우였음
- 회고를 적을 때 어제 적었는지를 확인하고 적었다면 기존 값 + 1로 증가, 안 적었다면 1로 고정


---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified streak tracking to reset when there's a gap in daily reflection entries, providing a more accurate count of consecutive reflection days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->