### PR TITLE
feat/reflection-feedback-generate-async

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackService.java
@@ -100,12 +100,11 @@ public class ReflectionFeedbackService {
             Long reflectionId,
             ReflectionFeedbackEntity existingFeedback
     ) {
-        if (existingFeedback.getStatus() == FeedbackStatus.COMPLETED) {
+        if (existingFeedback.getStatus() != FeedbackStatus.FAILED) {
             throw new BusinessException(ReflectionErrorCode.REFLECTION_FEEDBACK_ALREADY_EXISTS);
         }
 
-        log.info("Retrying feedback generation for reflectionId={}, previousStatus={}",
-                reflectionId, existingFeedback.getStatus());
+        log.info("Retrying failed reflection feedback generation for reflectionId={}", reflectionId);
         existingFeedback.restartProcessing();
         return existingFeedback;
     }

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackService.java
@@ -1,16 +1,13 @@
 package com.dnd5.timoapi.domain.reflection.application.service;
 
+import com.dnd5.timoapi.domain.reflection.application.support.ReflectionFeedbackAsyncProcessor;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionFeedbackEntity;
-import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionQuestionEntity;
 import com.dnd5.timoapi.domain.reflection.domain.model.ReflectionFeedback;
 import com.dnd5.timoapi.domain.reflection.domain.model.enums.FeedbackStatus;
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionFeedbackRepository;
-import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionQuestionRepository;
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
 import com.dnd5.timoapi.domain.reflection.exception.ReflectionErrorCode;
-import com.dnd5.timoapi.domain.reflection.infrastructure.ai.FeedbackGenerator;
-import com.dnd5.timoapi.domain.reflection.infrastructure.ai.FeedbackResult;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionFeedbackDetailResponse;
 import com.dnd5.timoapi.global.exception.BusinessException;
 import com.dnd5.timoapi.global.security.context.SecurityUtil;
@@ -18,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Service
@@ -25,22 +24,19 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class ReflectionFeedbackService {
 
-    private static final int MIN_FEEDBACK_SCORE = 0;
-    private static final int MAX_FEEDBACK_SCORE = 100;
-
     private final ReflectionFeedbackRepository reflectionFeedbackRepository;
     private final ReflectionRepository reflectionRepository;
-    private final FeedbackGenerator feedbackGenerator;
-    private final ReflectionQuestionRepository reflectionQuestionRepository;
+    private final ReflectionFeedbackAsyncProcessor reflectionFeedbackAsyncProcessor;
 
     public ReflectionFeedbackDetailResponse create(Long reflectionId) {
         Long currentUserId = SecurityUtil.getCurrentUserId();
-        String failureReason = null;
+
         ReflectionEntity reflectionEntity = reflectionRepository.findById(reflectionId)
                 .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_NOT_FOUND));
         validateOwnership(reflectionEntity, currentUserId);
 
-        ReflectionFeedbackEntity feedbackEntity = reflectionFeedbackRepository.findByReflectionId(reflectionId)
+        ReflectionFeedbackEntity feedbackEntity = reflectionFeedbackRepository
+                .findByReflectionId(reflectionId)
                 .map(existingFeedback -> prepareFeedbackForRegeneration(reflectionId, existingFeedback))
                 .orElseGet(() -> reflectionFeedbackRepository.save(ReflectionFeedbackEntity.from(
                         new ReflectionFeedback(
@@ -53,30 +49,34 @@ public class ReflectionFeedbackService {
                         )
                 )));
 
-        ReflectionQuestionEntity reflectionQuestionEntity =
-                reflectionQuestionRepository.findById(reflectionEntity.getQuestionId())
-                        .orElseThrow(() -> new BusinessException(
-                                ReflectionErrorCode.REFLECTION_QUESTION_NOT_FOUND));
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                try {
+                    reflectionFeedbackAsyncProcessor.process(reflectionId);
+                } catch (Exception e) {
+                    log.error("Failed to submit async feedback task for reflectionId={}", reflectionId, e);
+                    reflectionFeedbackAsyncProcessor.markAsFailed(reflectionId);
+                }
+            }
+        });
 
-        try {
-            FeedbackResult feedbackResult = feedbackGenerator.execute(
-                    reflectionQuestionEntity.getCategory(),
-                    reflectionQuestionEntity.getContent(),
-                    reflectionEntity.getAnswerText()
-            );
-            validateScore(feedbackResult.score());
-            feedbackEntity.complete(feedbackResult.score(), feedbackResult.content());
-        } catch (BusinessException e) {
-            log.error("Feedback generation failed with business error for reflectionId={}", reflectionId, e);
-            feedbackEntity.fail();
-            throw e;
-        } catch (Exception e) {
-            log.error("Feedback generation failed for reflectionId={}", reflectionId, e);
-            feedbackEntity.fail();
-            failureReason = extractFailureReason(e);
-        }
+        return ReflectionFeedbackDetailResponse.from(feedbackEntity.toModel());
+    }
 
-        return ReflectionFeedbackDetailResponse.from(feedbackEntity.toModel(), failureReason);
+    @Transactional(readOnly = true)
+    public ReflectionFeedbackDetailResponse findByReflectionId(Long reflectionId) {
+        Long currentUserId = SecurityUtil.getCurrentUserId();
+
+        ReflectionEntity reflectionEntity = reflectionRepository.findById(reflectionId)
+                .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_NOT_FOUND));
+        validateOwnership(reflectionEntity, currentUserId);
+
+        ReflectionFeedbackEntity feedbackEntity = reflectionFeedbackRepository
+                .findByReflectionId(reflectionId)
+                .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_FEEDBACK_NOT_FOUND));
+
+        return ReflectionFeedbackDetailResponse.from(feedbackEntity.toModel());
     }
 
     public void delete(Long feedbackId) {
@@ -100,34 +100,13 @@ public class ReflectionFeedbackService {
             Long reflectionId,
             ReflectionFeedbackEntity existingFeedback
     ) {
-        if (existingFeedback.getStatus() != FeedbackStatus.FAILED) {
+        if (existingFeedback.getStatus() == FeedbackStatus.COMPLETED) {
             throw new BusinessException(ReflectionErrorCode.REFLECTION_FEEDBACK_ALREADY_EXISTS);
         }
 
-        log.info("Retrying failed reflection feedback generation for reflectionId={}", reflectionId);
+        log.info("Retrying feedback generation for reflectionId={}, previousStatus={}",
+                reflectionId, existingFeedback.getStatus());
         existingFeedback.restartProcessing();
         return existingFeedback;
-    }
-
-    private void validateScore(int score) {
-        if (score < MIN_FEEDBACK_SCORE || score > MAX_FEEDBACK_SCORE) {
-            throw new BusinessException(
-                    ReflectionErrorCode.REFLECTION_FEEDBACK_SCORE_OUT_OF_RANGE,
-                    score,
-                    MIN_FEEDBACK_SCORE,
-                    MAX_FEEDBACK_SCORE
-            );
-        }
-    }
-
-    private String extractFailureReason(Exception e) {
-        Throwable root = e;
-        while (root.getCause() != null) {
-            root = root.getCause();
-        }
-        if (root.getMessage() != null && !root.getMessage().isBlank()) {
-            return root.getMessage();
-        }
-        return "피드백 생성 중 알 수 없는 오류가 발생했습니다.";
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/support/ReflectionFeedbackAsyncProcessor.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/support/ReflectionFeedbackAsyncProcessor.java
@@ -36,14 +36,14 @@ public class ReflectionFeedbackAsyncProcessor {
                 .findByReflectionId(reflectionId)
                 .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_FEEDBACK_NOT_FOUND));
 
-        ReflectionEntity reflectionEntity = reflectionRepository.findById(reflectionId)
-                .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_NOT_FOUND));
-
-        ReflectionQuestionEntity questionEntity = reflectionQuestionRepository
-                .findById(reflectionEntity.getQuestionId())
-                .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_QUESTION_NOT_FOUND));
-
         try {
+            ReflectionEntity reflectionEntity = reflectionRepository.findById(reflectionId)
+                    .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_NOT_FOUND));
+
+            ReflectionQuestionEntity questionEntity = reflectionQuestionRepository
+                    .findById(reflectionEntity.getQuestionId())
+                    .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_QUESTION_NOT_FOUND));
+
             FeedbackResult feedbackResult = feedbackGenerator.execute(
                     questionEntity.getCategory(),
                     questionEntity.getContent(),

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/support/ReflectionFeedbackAsyncProcessor.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/support/ReflectionFeedbackAsyncProcessor.java
@@ -1,0 +1,76 @@
+package com.dnd5.timoapi.domain.reflection.application.support;
+
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionFeedbackEntity;
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionQuestionEntity;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionFeedbackRepository;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionQuestionRepository;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
+import com.dnd5.timoapi.domain.reflection.exception.ReflectionErrorCode;
+import com.dnd5.timoapi.domain.reflection.infrastructure.ai.FeedbackGenerator;
+import com.dnd5.timoapi.domain.reflection.infrastructure.ai.FeedbackResult;
+import com.dnd5.timoapi.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReflectionFeedbackAsyncProcessor {
+
+    private static final int MIN_FEEDBACK_SCORE = 0;
+    private static final int MAX_FEEDBACK_SCORE = 5;
+
+    private final ReflectionRepository reflectionRepository;
+    private final ReflectionFeedbackRepository reflectionFeedbackRepository;
+    private final ReflectionQuestionRepository reflectionQuestionRepository;
+    private final FeedbackGenerator feedbackGenerator;
+
+    @Async("feedbackTaskExecutor")
+    @Transactional
+    public void process(Long reflectionId) {
+        ReflectionFeedbackEntity feedbackEntity = reflectionFeedbackRepository
+                .findByReflectionId(reflectionId)
+                .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_FEEDBACK_NOT_FOUND));
+
+        ReflectionEntity reflectionEntity = reflectionRepository.findById(reflectionId)
+                .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_NOT_FOUND));
+
+        ReflectionQuestionEntity questionEntity = reflectionQuestionRepository
+                .findById(reflectionEntity.getQuestionId())
+                .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_QUESTION_NOT_FOUND));
+
+        try {
+            FeedbackResult feedbackResult = feedbackGenerator.execute(
+                    questionEntity.getCategory(),
+                    questionEntity.getContent(),
+                    reflectionEntity.getAnswerText()
+            );
+            validateScore(feedbackResult.score());
+            feedbackEntity.complete(feedbackResult.score(), feedbackResult.content());
+        } catch (Exception e) {
+            log.error("Feedback generation failed for reflectionId={}", reflectionId, e);
+            feedbackEntity.fail();
+        }
+    }
+
+    @Transactional
+    public void markAsFailed(Long reflectionId) {
+        reflectionFeedbackRepository.findByReflectionId(reflectionId)
+                .ifPresent(ReflectionFeedbackEntity::fail);
+    }
+
+    private void validateScore(int score) {
+        if (score < MIN_FEEDBACK_SCORE || score > MAX_FEEDBACK_SCORE) {
+            throw new BusinessException(
+                    ReflectionErrorCode.REFLECTION_FEEDBACK_SCORE_OUT_OF_RANGE,
+                    score,
+                    MIN_FEEDBACK_SCORE,
+                    MAX_FEEDBACK_SCORE
+            );
+        }
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/presentation/ReflectionFeedbackController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/presentation/ReflectionFeedbackController.java
@@ -3,9 +3,11 @@ package com.dnd5.timoapi.domain.reflection.presentation;
 import com.dnd5.timoapi.domain.reflection.application.service.ReflectionFeedbackService;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionFeedbackDetailResponse;
 import jakarta.validation.constraints.Positive;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,8 +23,13 @@ public class ReflectionFeedbackController {
     private final ReflectionFeedbackService reflectionFeedbackService;
 
     @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
+    @ResponseStatus(HttpStatus.ACCEPTED)
     public ReflectionFeedbackDetailResponse create(@Positive @PathVariable Long reflectionId) {
         return reflectionFeedbackService.create(reflectionId);
+    }
+
+    @GetMapping
+    public ReflectionFeedbackDetailResponse findById(@Positive @PathVariable Long reflectionId) {
+        return reflectionFeedbackService.findByReflectionId(reflectionId);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/global/infrastructure/async/AsyncConfig.java
+++ b/src/main/java/com/dnd5/timoapi/global/infrastructure/async/AsyncConfig.java
@@ -1,0 +1,38 @@
+package com.dnd5.timoapi.global.infrastructure.async;
+
+import java.util.Map;
+import java.util.concurrent.Executor;
+import org.slf4j.MDC;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "feedbackTaskExecutor")
+    public Executor feedbackTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("feedback-async-");
+        executor.setTaskDecorator(runnable -> {
+            Map<String, String> mdcContext = MDC.getCopyOfContextMap();
+            return () -> {
+                try {
+                    if (mdcContext != null) {
+                        MDC.setContextMap(mdcContext);
+                    }
+                    runnable.run();
+                } finally {
+                    MDC.clear();
+                }
+            };
+        });
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/test/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackServiceTest.java
+++ b/src/test/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackServiceTest.java
@@ -118,30 +118,26 @@ class ReflectionFeedbackServiceTest {
     }
 
     @Test
-    void create_PROCESSING_기존_피드백도_재시도_허용() {
+    void create_PROCESSING_기존_피드백은_재생성_불가() {
         Long reflectionId = 10L;
         ReflectionEntity reflectionEntity = new ReflectionEntity(1L, 3L, LocalDate.now(), "회고 내용");
         when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflectionEntity));
 
-        ReflectionFeedbackEntity processingFeedback = spy(
-                new ReflectionFeedbackEntity(reflectionId, 0, null, FeedbackStatus.PROCESSING)
-        );
+        ReflectionFeedbackEntity processingFeedback = new ReflectionFeedbackEntity(reflectionId, 0, null, FeedbackStatus.PROCESSING);
         when(reflectionFeedbackRepository.findByReflectionId(reflectionId))
                 .thenReturn(Optional.of(processingFeedback));
 
-        try (MockedStatic<SecurityUtil> securityMocked = Mockito.mockStatic(SecurityUtil.class);
-             MockedStatic<TransactionSynchronizationManager> txMocked = Mockito.mockStatic(TransactionSynchronizationManager.class)) {
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(1L);
 
-            securityMocked.when(SecurityUtil::getCurrentUserId).thenReturn(1L);
-            txMocked.when(() -> TransactionSynchronizationManager.registerSynchronization(any(TransactionSynchronization.class)))
-                    .thenAnswer(invocation -> null);
-
-            ReflectionFeedbackDetailResponse response = reflectionFeedbackService.create(reflectionId);
-
-            assertThat(response.status()).isEqualTo(FeedbackStatus.PROCESSING);
+            assertThatThrownBy(() -> reflectionFeedbackService.create(reflectionId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(exception -> {
+                        BusinessException businessException = (BusinessException) exception;
+                        assertThat(businessException.getErrorCode())
+                                .isEqualTo(ReflectionErrorCode.REFLECTION_FEEDBACK_ALREADY_EXISTS);
+                    });
         }
-
-        verify(processingFeedback).restartProcessing();
     }
 
     @Test

--- a/src/test/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackServiceTest.java
+++ b/src/test/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackServiceTest.java
@@ -3,24 +3,19 @@ package com.dnd5.timoapi.domain.reflection.application.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.dnd5.timoapi.domain.reflection.application.support.ReflectionFeedbackAsyncProcessor;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionFeedbackEntity;
-import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionQuestionEntity;
 import com.dnd5.timoapi.domain.reflection.domain.model.enums.FeedbackStatus;
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionFeedbackRepository;
-import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionQuestionRepository;
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
 import com.dnd5.timoapi.domain.reflection.exception.ReflectionErrorCode;
-import com.dnd5.timoapi.domain.reflection.infrastructure.ai.FeedbackGenerator;
-import com.dnd5.timoapi.domain.reflection.infrastructure.ai.FeedbackResult;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionFeedbackDetailResponse;
-import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import com.dnd5.timoapi.global.exception.BusinessException;
 import com.dnd5.timoapi.global.security.context.SecurityUtil;
 import java.time.LocalDate;
@@ -32,6 +27,8 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @ExtendWith(MockitoExtension.class)
 class ReflectionFeedbackServiceTest {
@@ -46,10 +43,7 @@ class ReflectionFeedbackServiceTest {
     private ReflectionRepository reflectionRepository;
 
     @Mock
-    private FeedbackGenerator feedbackGenerator;
-
-    @Mock
-    private ReflectionQuestionRepository reflectionQuestionRepository;
+    private ReflectionFeedbackAsyncProcessor reflectionFeedbackAsyncProcessor;
 
     @Test
     void create_다른_유저_회고면_403_예외() {
@@ -73,12 +67,32 @@ class ReflectionFeedbackServiceTest {
     }
 
     @Test
+    void create_신규_피드백은_PROCESSING_상태로_즉시_반환() {
+        Long reflectionId = 10L;
+        ReflectionEntity reflectionEntity = new ReflectionEntity(1L, 3L, LocalDate.now(), "회고 내용");
+        when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflectionEntity));
+        when(reflectionFeedbackRepository.findByReflectionId(reflectionId)).thenReturn(Optional.empty());
+
+        ReflectionFeedbackEntity processingFeedback = new ReflectionFeedbackEntity(reflectionId, 0, null, FeedbackStatus.PROCESSING);
+        when(reflectionFeedbackRepository.save(any())).thenReturn(processingFeedback);
+
+        try (MockedStatic<SecurityUtil> securityMocked = Mockito.mockStatic(SecurityUtil.class);
+             MockedStatic<TransactionSynchronizationManager> txMocked = Mockito.mockStatic(TransactionSynchronizationManager.class)) {
+
+            securityMocked.when(SecurityUtil::getCurrentUserId).thenReturn(1L);
+            txMocked.when(() -> TransactionSynchronizationManager.registerSynchronization(any(TransactionSynchronization.class)))
+                    .thenAnswer(invocation -> null);
+
+            ReflectionFeedbackDetailResponse response = reflectionFeedbackService.create(reflectionId);
+
+            assertThat(response.status()).isEqualTo(FeedbackStatus.PROCESSING);
+        }
+    }
+
+    @Test
     void create_FAILED_기존_피드백은_재생성_허용() {
         Long reflectionId = 10L;
-        Long questionId = 3L;
-        String answerText = "회고 내용";
-
-        ReflectionEntity reflectionEntity = new ReflectionEntity(1L, questionId, LocalDate.now(), answerText);
+        ReflectionEntity reflectionEntity = new ReflectionEntity(1L, 3L, LocalDate.now(), "회고 내용");
         when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflectionEntity));
 
         ReflectionFeedbackEntity failedFeedback = spy(
@@ -87,49 +101,58 @@ class ReflectionFeedbackServiceTest {
         when(reflectionFeedbackRepository.findByReflectionId(reflectionId))
                 .thenReturn(Optional.of(failedFeedback));
 
-        ReflectionQuestionEntity questionEntity = new ReflectionQuestionEntity(
-                1L, ZtpiCategory.FUTURE, "질문", "system"
-        );
-        when(reflectionQuestionRepository.findById(questionId)).thenReturn(Optional.of(questionEntity));
-        when(feedbackGenerator.execute(ZtpiCategory.FUTURE, "질문", answerText))
-                .thenReturn(new FeedbackResult(80, "피드백"));
+        try (MockedStatic<SecurityUtil> securityMocked = Mockito.mockStatic(SecurityUtil.class);
+             MockedStatic<TransactionSynchronizationManager> txMocked = Mockito.mockStatic(TransactionSynchronizationManager.class)) {
 
-        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
-            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(1L);
+            securityMocked.when(SecurityUtil::getCurrentUserId).thenReturn(1L);
+            txMocked.when(() -> TransactionSynchronizationManager.registerSynchronization(any(TransactionSynchronization.class)))
+                    .thenAnswer(invocation -> null);
 
             ReflectionFeedbackDetailResponse response = reflectionFeedbackService.create(reflectionId);
 
-            assertThat(response.score()).isEqualTo(80);
-            assertThat(response.status()).isEqualTo(FeedbackStatus.COMPLETED);
-            assertThat(response.failureReason()).isNull();
+            assertThat(response.status()).isEqualTo(FeedbackStatus.PROCESSING);
         }
 
         verify(failedFeedback).restartProcessing();
-        verify(failedFeedback).complete(80, "피드백");
         verify(reflectionFeedbackRepository, never()).save(any());
     }
 
     @Test
-    void create_score_범위_초과시_예외_반환() {
+    void create_PROCESSING_기존_피드백도_재시도_허용() {
         Long reflectionId = 10L;
-        Long questionId = 3L;
-        String answerText = "회고 내용";
-
-        ReflectionEntity reflectionEntity = new ReflectionEntity(1L, questionId, LocalDate.now(), answerText);
+        ReflectionEntity reflectionEntity = new ReflectionEntity(1L, 3L, LocalDate.now(), "회고 내용");
         when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflectionEntity));
 
         ReflectionFeedbackEntity processingFeedback = spy(
                 new ReflectionFeedbackEntity(reflectionId, 0, null, FeedbackStatus.PROCESSING)
         );
-        when(reflectionFeedbackRepository.findByReflectionId(reflectionId)).thenReturn(Optional.empty());
-        when(reflectionFeedbackRepository.save(any(ReflectionFeedbackEntity.class))).thenReturn(processingFeedback);
+        when(reflectionFeedbackRepository.findByReflectionId(reflectionId))
+                .thenReturn(Optional.of(processingFeedback));
 
-        ReflectionQuestionEntity questionEntity = new ReflectionQuestionEntity(
-                1L, ZtpiCategory.FUTURE, "질문", "system"
-        );
-        when(reflectionQuestionRepository.findById(questionId)).thenReturn(Optional.of(questionEntity));
-        when(feedbackGenerator.execute(ZtpiCategory.FUTURE, "질문", answerText))
-                .thenReturn(new FeedbackResult(200, "피드백"));
+        try (MockedStatic<SecurityUtil> securityMocked = Mockito.mockStatic(SecurityUtil.class);
+             MockedStatic<TransactionSynchronizationManager> txMocked = Mockito.mockStatic(TransactionSynchronizationManager.class)) {
+
+            securityMocked.when(SecurityUtil::getCurrentUserId).thenReturn(1L);
+            txMocked.when(() -> TransactionSynchronizationManager.registerSynchronization(any(TransactionSynchronization.class)))
+                    .thenAnswer(invocation -> null);
+
+            ReflectionFeedbackDetailResponse response = reflectionFeedbackService.create(reflectionId);
+
+            assertThat(response.status()).isEqualTo(FeedbackStatus.PROCESSING);
+        }
+
+        verify(processingFeedback).restartProcessing();
+    }
+
+    @Test
+    void create_COMPLETED_기존_피드백은_재생성_불가() {
+        Long reflectionId = 10L;
+        ReflectionEntity reflectionEntity = new ReflectionEntity(1L, 3L, LocalDate.now(), "회고 내용");
+        when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflectionEntity));
+
+        ReflectionFeedbackEntity completedFeedback = new ReflectionFeedbackEntity(reflectionId, 80, "피드백", FeedbackStatus.COMPLETED);
+        when(reflectionFeedbackRepository.findByReflectionId(reflectionId))
+                .thenReturn(Optional.of(completedFeedback));
 
         try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
             mocked.when(SecurityUtil::getCurrentUserId).thenReturn(1L);
@@ -139,44 +162,8 @@ class ReflectionFeedbackServiceTest {
                     .satisfies(exception -> {
                         BusinessException businessException = (BusinessException) exception;
                         assertThat(businessException.getErrorCode())
-                                .isEqualTo(ReflectionErrorCode.REFLECTION_FEEDBACK_SCORE_OUT_OF_RANGE);
+                                .isEqualTo(ReflectionErrorCode.REFLECTION_FEEDBACK_ALREADY_EXISTS);
                     });
         }
-
-        verify(processingFeedback).fail();
-        verify(processingFeedback, never()).complete(anyInt(), any(String.class));
-    }
-
-    @Test
-    void create_예외로_FAILED_처리되면_실패원인_반환() {
-        Long reflectionId = 10L;
-        Long questionId = 3L;
-        String answerText = "회고 내용";
-
-        ReflectionEntity reflectionEntity = new ReflectionEntity(1L, questionId, LocalDate.now(), answerText);
-        when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflectionEntity));
-
-        ReflectionFeedbackEntity processingFeedback = spy(
-                new ReflectionFeedbackEntity(reflectionId, 0, null, FeedbackStatus.PROCESSING)
-        );
-        when(reflectionFeedbackRepository.findByReflectionId(reflectionId)).thenReturn(Optional.empty());
-        when(reflectionFeedbackRepository.save(any(ReflectionFeedbackEntity.class))).thenReturn(processingFeedback);
-
-        ReflectionQuestionEntity questionEntity = new ReflectionQuestionEntity(
-                1L, ZtpiCategory.FUTURE, "질문", "system"
-        );
-        when(reflectionQuestionRepository.findById(questionId)).thenReturn(Optional.of(questionEntity));
-        when(feedbackGenerator.execute(ZtpiCategory.FUTURE, "질문", answerText))
-                .thenThrow(new RuntimeException("Gemini timeout"));
-
-        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
-            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(1L);
-
-            ReflectionFeedbackDetailResponse response = reflectionFeedbackService.create(reflectionId);
-            assertThat(response.status()).isEqualTo(FeedbackStatus.FAILED);
-            assertThat(response.failureReason()).isEqualTo("Gemini timeout");
-        }
-
-        verify(processingFeedback).fail();
     }
 }


### PR DESCRIPTION
## What is this PR? :mag:                                                                                                                                                                              
- 피드백 생성 API의 동기 처리 방식으로 인해 Gemini API 응답 대기 중 클라이언트 타임아웃이 발생하는 문제를 해결                                                                                   
- 비동기 처리 방식으로 전환하여 즉시 응답을 반환
- 프론트엔드가 N초 간격 폴링으로 완료 여부를 확인하도록 구조 변경
                                                                                                                                                                                                         
## Changes :memo:
변경 전
```
POST /reflections/{id}/feedback
    -> PROCESSING 상태 DB 저장 -> Gemini 호출 시작 -> Gemini 응답 -> 프론트에게 201 반환
```
- Gemini 호출 ~ 응답 과정에서 클라이언트가 타임아웃으로 오해

변경 후                                                                                                                                                                                             
```
POST /reflections/{id}/feedback
    → PROCESSING 상태 DB 저장 → 비동기 Gemini 호출 시작 (생성 성공 시 COMPLETED, 실패 시 FAILED 상태 저장) → 프론트에게 202 반환

GET /reflections/{id}/feedback  (프론트가 N초마다 폴링)
    → { status: "PROCESSING" }
    → { status: "PROCESSING" }
    → { status: "COMPLETED", content: "...", score: 3 }  → 피드백 결과 화면 전환
```

## Screenshot  :camera:
로컬 테스트 성공했습니다!
<img width="712" height="556" alt="스크린샷 2026-04-08 오전 12 10 32" src="https://github.com/user-attachments/assets/17756737-878d-4685-8b18-5bbb7ffd9ac0" />

---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GET endpoint to fetch reflection feedback by reflection ID.

* **Refactor**
  * Feedback generation now runs asynchronously; create requests return 202 Accepted and report PROCESSING immediately.
  * Introduced background processing with improved logging/context propagation for async tasks.

* **Behavior Changes**
  * Regeneration can be retried unless feedback is already COMPLETED; failures are recorded and mark feedback as FAILED.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->