### PR TITLE
feat/elasticsearch-kibana-initial-settings

### DIFF
--- a/logstash/pipeline/logstash.conf
+++ b/logstash/pipeline/logstash.conf
@@ -8,7 +8,6 @@ input {
 filter {
   json {
     source => "message"
-    target => "payload"
     skip_on_invalid_json => true
     remove_field => ["message"]
   }

--- a/logstash/pipeline/logstash.conf
+++ b/logstash/pipeline/logstash.conf
@@ -13,12 +13,12 @@ filter {
     remove_field => ["message"]
   }
 
-  if [logType] == "API" {
-    mutate { add_field => { "[@metadata][index]" => "api-logs" } }
-  } else if [logType] == "ERROR" {
+  if [level] == "ERROR" {
     mutate { add_field => { "[@metadata][index]" => "error-logs" } }
-  } else if [logType] == "WARN" {
+  } else if [level] == "WARN" {
     mutate { add_field => { "[@metadata][index]" => "warn-logs" } }
+  } else if [logType] == "API" {
+    mutate { add_field => { "[@metadata][index]" => "api-logs" } }
   } else {
     mutate { add_field => { "[@metadata][index]" => "app-logs" } }
   }

--- a/logstash/pipeline/logstash.conf
+++ b/logstash/pipeline/logstash.conf
@@ -12,20 +12,26 @@ filter {
     remove_field => ["message"]
   }
 
-  if [level] == "ERROR" {
-    mutate { add_field => { "[@metadata][index]" => "error-logs" } }
-  } else if [level] == "WARN" {
-    mutate { add_field => { "[@metadata][index]" => "warn-logs" } }
-  } else if [logType] == "API" {
-    mutate { add_field => { "[@metadata][index]" => "api-logs" } }
+  if [apiType] == "ADMIN" {
+    mutate { add_field => { "[@metadata][prefix]" => "timo-admin" } }
   } else {
-    mutate { add_field => { "[@metadata][index]" => "app-logs" } }
+    mutate { add_field => { "[@metadata][prefix]" => "timo-app" } }
+  }
+
+  if [level] == "ERROR" {
+    mutate { add_field => { "[@metadata][suffix]" => "error-logs" } }
+  } else if [level] == "WARN" {
+    mutate { add_field => { "[@metadata][suffix]" => "warn-logs" } }
+  } else if [logType] == "API" {
+    mutate { add_field => { "[@metadata][suffix]" => "api-logs" } }
+  } else {
+    mutate { add_field => { "[@metadata][suffix]" => "app-logs" } }
   }
 }
 
 output {
   elasticsearch {
     hosts => ["http://${ELASTICSEARCH_HOST:timo-elasticsearch}:${ELASTICSEARCH_PORT:9200}"]
-    index => "%{[@metadata][index]}-%{+YYYY.MM.dd}"
+    index => "%{[@metadata][prefix]}-%{[@metadata][suffix]}-%{+YYYY.MM.dd}"
   }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/notification/application/service/FcmService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/notification/application/service/FcmService.java
@@ -8,20 +8,21 @@ import com.dnd5.timoapi.global.exception.BusinessException;
 import com.dnd5.timoapi.global.infrastructure.fcm.FcmMessage;
 import com.dnd5.timoapi.global.infrastructure.fcm.FcmSender;
 import com.dnd5.timoapi.global.security.context.SecurityUtil;
+import com.dnd5.timoapi.global.analytics.event.NotificationSentEvent;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class FcmService {
 
+    private final ApplicationEventPublisher eventPublisher;
     private final FcmTokenRepository fcmTokenRepository;
     private final FcmSender fcmSender;
 
@@ -60,7 +61,7 @@ public class FcmService {
 
         if (tokens.isEmpty()) return;
 
-        log.info("fcm_send_attempt userId={} tokenCount={}", userId, tokens.size());
+        eventPublisher.publishEvent(new NotificationSentEvent(userId, tokens.size()));
         fcmSender.sendToTokens(tokens, message);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/notification/application/service/FcmService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/notification/application/service/FcmService.java
@@ -9,12 +9,14 @@ import com.dnd5.timoapi.global.infrastructure.fcm.FcmMessage;
 import com.dnd5.timoapi.global.infrastructure.fcm.FcmSender;
 import com.dnd5.timoapi.global.security.context.SecurityUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -58,6 +60,7 @@ public class FcmService {
 
         if (tokens.isEmpty()) return;
 
+        log.info("fcm_send_attempt userId={} tokenCount={}", userId, tokens.size());
         fcmSender.sendToTokens(tokens, message);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionService.java
@@ -30,9 +30,11 @@ import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -64,6 +66,8 @@ public class ReflectionService {
                 null
         );
         ReflectionEntity saved = reflectionRepository.save(ReflectionEntity.from(reflectionModel));
+        log.info("reflection_created reflectionId={} userId={} questionId={} category={} answerLength={}",
+                saved.getId(), userId, questionEntity.getId(), questionEntity.getCategory(), request.content().length());
 
         UserEntity userEntity = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionService.java
@@ -29,17 +29,18 @@ import com.dnd5.timoapi.global.security.context.SecurityUtil;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
+import com.dnd5.timoapi.global.analytics.event.ReflectionCreatedEvent;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class ReflectionService {
 
+    private final ApplicationEventPublisher eventPublisher;
     private final ReflectionRepository reflectionRepository;
     private final ReflectionQuestionRepository reflectionQuestionRepository;
     private final ReflectionFeedbackRepository reflectionFeedbackRepository;
@@ -66,8 +67,8 @@ public class ReflectionService {
                 null
         );
         ReflectionEntity saved = reflectionRepository.save(ReflectionEntity.from(reflectionModel));
-        log.info("reflection_created reflectionId={} userId={} questionId={} category={} answerLength={}",
-                saved.getId(), userId, questionEntity.getId(), questionEntity.getCategory(), request.content().length());
+        eventPublisher.publishEvent(new ReflectionCreatedEvent(
+                userId, saved.getId(), questionEntity.getId(), questionEntity.getCategory(), request.content().length()));
 
         UserEntity userEntity = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/support/ReflectionFeedbackAsyncProcessor.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/support/ReflectionFeedbackAsyncProcessor.java
@@ -32,6 +32,7 @@ public class ReflectionFeedbackAsyncProcessor {
     @Async("feedbackTaskExecutor")
     @Transactional
     public void process(Long reflectionId) {
+        log.info("feedback_async_start reflectionId={}", reflectionId);
         ReflectionFeedbackEntity feedbackEntity = reflectionFeedbackRepository
                 .findByReflectionId(reflectionId)
                 .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_FEEDBACK_NOT_FOUND));
@@ -51,6 +52,7 @@ public class ReflectionFeedbackAsyncProcessor {
             );
             validateScore(feedbackResult.score());
             feedbackEntity.complete(feedbackResult.score(), feedbackResult.content());
+            log.info("feedback_async_done reflectionId={} score={}", reflectionId, feedbackResult.score());
         } catch (Exception e) {
             log.error("Feedback generation failed for reflectionId={}", reflectionId, e);
             feedbackEntity.fail();

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/support/ReflectionFeedbackAsyncProcessor.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/support/ReflectionFeedbackAsyncProcessor.java
@@ -10,8 +10,10 @@ import com.dnd5.timoapi.domain.reflection.exception.ReflectionErrorCode;
 import com.dnd5.timoapi.domain.reflection.infrastructure.ai.FeedbackGenerator;
 import com.dnd5.timoapi.domain.reflection.infrastructure.ai.FeedbackResult;
 import com.dnd5.timoapi.global.exception.BusinessException;
+import com.dnd5.timoapi.global.analytics.event.FeedbackReceivedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +26,7 @@ public class ReflectionFeedbackAsyncProcessor {
     private static final int MIN_FEEDBACK_SCORE = 0;
     private static final int MAX_FEEDBACK_SCORE = 5;
 
+    private final ApplicationEventPublisher eventPublisher;
     private final ReflectionRepository reflectionRepository;
     private final ReflectionFeedbackRepository reflectionFeedbackRepository;
     private final ReflectionQuestionRepository reflectionQuestionRepository;
@@ -52,7 +55,9 @@ public class ReflectionFeedbackAsyncProcessor {
             );
             validateScore(feedbackResult.score());
             feedbackEntity.complete(feedbackResult.score(), feedbackResult.content());
-            log.info("feedback_async_done reflectionId={} score={}", reflectionId, feedbackResult.score());
+
+            Long userId = reflectionEntity.getUserId();
+            eventPublisher.publishEvent(new FeedbackReceivedEvent(userId, reflectionId, feedbackResult.score()));
         } catch (Exception e) {
             log.error("Feedback generation failed for reflectionId={}", reflectionId, e);
             feedbackEntity.fail();

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/support/TodayQuestionResolver.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/support/TodayQuestionResolver.java
@@ -17,8 +17,10 @@ import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class TodayQuestionResolver {
@@ -40,6 +42,7 @@ public class TodayQuestionResolver {
         Long questionId = findQuestionId(sequence, category);
 
         cacheService.setQuestionId(userId, questionId);
+        log.info("question_resolved userId={} category={} questionId={}", userId, category, questionId);
         return questionId;
     }
 
@@ -61,7 +64,9 @@ public class TodayQuestionResolver {
                         UserTestResultEntity::getCategory,
                         UserTestResultEntity::getScore));
 
-        return selectWeightedRandom(scoreMap);
+        ZtpiCategory selected = selectWeightedRandom(scoreMap);
+        log.info("question_category_resolved userId={} scores={} selected={}", userId, scoreMap, selected);
+        return selected;
     }
 
     public Long resolveTodaySequence(Long userId, ZtpiCategory category) {

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/infrastructure/ai/FeedbackGeneratorImpl.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/infrastructure/ai/FeedbackGeneratorImpl.java
@@ -7,9 +7,11 @@ import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import com.dnd5.timoapi.global.exception.BusinessException;
 import com.dnd5.timoapi.global.infrastructure.gemini.GeminiClient;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class FeedbackGeneratorImpl implements FeedbackGenerator {
@@ -20,13 +22,16 @@ public class FeedbackGeneratorImpl implements FeedbackGenerator {
 
     @Override
     public FeedbackResult execute(ZtpiCategory category, String question, String userReflection) {
+        log.info("feedback_generate_start category={} questionLen={} reflectionLen={}", category, question.length(), userReflection.length());
         String systemPrompt = getLatestSystemPrompt();
         String userPrompt = buildUserPrompt(category, question, userReflection);
         String response = geminiClient.generateContent(systemPrompt, userPrompt);
         if (response == null || response.isBlank()) {
             return new FeedbackResult(0, "");
         }
-        return parseResponse(response);
+        FeedbackResult result = parseResponse(response);
+        log.info("feedback_generate_done category={} score={}", category, result.score());
+        return result;
     }
 
     private String getLatestSystemPrompt() {
@@ -58,6 +63,7 @@ public class FeedbackGeneratorImpl implements FeedbackGenerator {
             }
             return objectMapper.readValue(cleaned, FeedbackResult.class);
         } catch (Exception e) {
+            log.error("feedback_parse_failed raw={}", response, e);
             throw new RuntimeException("Failed to parse Gemini response: ", e);
         }
     }

--- a/src/main/java/com/dnd5/timoapi/domain/user/application/service/UserTestRecordService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/application/service/UserTestRecordService.java
@@ -38,17 +38,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import com.dnd5.timoapi.global.analytics.event.TestCompletedEvent;
+import com.dnd5.timoapi.global.analytics.event.TestStartedEvent;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class UserTestRecordService {
 
+    private final ApplicationEventPublisher eventPublisher;
     private final UserRepository userRepository;
     private final TestRepository testRepository;
 
@@ -89,13 +91,13 @@ public class UserTestRecordService {
                 userTestRecordRepository.save(
                         UserTestRecordEntity.from(userEntity, testEntity, model));
 
+        eventPublisher.publishEvent(new TestStartedEvent(userId, savedEntity.getId()));
         return UserTestRecordCreateResponse.from(savedEntity.toModel(), false);
     }
 
     public UserTestRecordDetailResponse complete(Long testRecordId) {
         UserTestRecordEntity userTestRecordEntity = getUserTestRecordEntity(testRecordId);
         Long userId = userTestRecordEntity.getUser().getId();
-        log.info("test_complete_start testRecordId={} userId={}", testRecordId, userId);
 
         if (userTestRecordEntity.isCompleted()) {
             throw new BusinessException(UserTestRecordErrorCode.ALREADY_COMPLETED);
@@ -120,9 +122,9 @@ public class UserTestRecordService {
         validateAllQuestionsAnswered(testQuestionEntityList, userTestResponseEntityList);
         Map<ZtpiCategory, Double> userTestResults = createUserTestResults(userTestRecordEntity,
                 userTestResponseEntityList);
-        log.info("test_complete_done testRecordId={} userId={} scores={}", testRecordId, userId, userTestResults);
 
         userTestRecordEntity.complete();
+        eventPublisher.publishEvent(new TestCompletedEvent(userId, testRecordId, userTestResults));
 
         UserEntity userEntity = userTestRecordEntity.getUser();
 

--- a/src/main/java/com/dnd5/timoapi/domain/user/application/service/UserTestRecordService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/application/service/UserTestRecordService.java
@@ -39,9 +39,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -92,6 +94,8 @@ public class UserTestRecordService {
 
     public UserTestRecordDetailResponse complete(Long testRecordId) {
         UserTestRecordEntity userTestRecordEntity = getUserTestRecordEntity(testRecordId);
+        Long userId = userTestRecordEntity.getUser().getId();
+        log.info("test_complete_start testRecordId={} userId={}", testRecordId, userId);
 
         if (userTestRecordEntity.isCompleted()) {
             throw new BusinessException(UserTestRecordErrorCode.ALREADY_COMPLETED);
@@ -116,6 +120,7 @@ public class UserTestRecordService {
         validateAllQuestionsAnswered(testQuestionEntityList, userTestResponseEntityList);
         Map<ZtpiCategory, Double> userTestResults = createUserTestResults(userTestRecordEntity,
                 userTestResponseEntityList);
+        log.info("test_complete_done testRecordId={} userId={} scores={}", testRecordId, userId, userTestResults);
 
         userTestRecordEntity.complete();
 

--- a/src/main/java/com/dnd5/timoapi/global/analytics/domain/entity/AnalyticsEventEntity.java
+++ b/src/main/java/com/dnd5/timoapi/global/analytics/domain/entity/AnalyticsEventEntity.java
@@ -1,0 +1,42 @@
+package com.dnd5.timoapi.global.analytics.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "analytics_events")
+public class AnalyticsEventEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "event_name", nullable = false)
+    private String eventName;
+
+    @Column(columnDefinition = "TEXT")
+    private String properties;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public AnalyticsEventEntity(Long userId, String eventName, String properties) {
+        this.userId = userId;
+        this.eventName = eventName;
+        this.properties = properties;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/global/analytics/domain/repository/AnalyticsEventRepository.java
+++ b/src/main/java/com/dnd5/timoapi/global/analytics/domain/repository/AnalyticsEventRepository.java
@@ -1,0 +1,7 @@
+package com.dnd5.timoapi.global.analytics.domain.repository;
+
+import com.dnd5.timoapi.global.analytics.domain.entity.AnalyticsEventEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnalyticsEventRepository extends JpaRepository<AnalyticsEventEntity, Long> {
+}

--- a/src/main/java/com/dnd5/timoapi/global/analytics/event/FeedbackReceivedEvent.java
+++ b/src/main/java/com/dnd5/timoapi/global/analytics/event/FeedbackReceivedEvent.java
@@ -1,0 +1,4 @@
+package com.dnd5.timoapi.global.analytics.event;
+
+public record FeedbackReceivedEvent(Long userId, Long reflectionId, int score) {
+}

--- a/src/main/java/com/dnd5/timoapi/global/analytics/event/NotificationSentEvent.java
+++ b/src/main/java/com/dnd5/timoapi/global/analytics/event/NotificationSentEvent.java
@@ -1,0 +1,4 @@
+package com.dnd5.timoapi.global.analytics.event;
+
+public record NotificationSentEvent(Long userId, int tokenCount) {
+}

--- a/src/main/java/com/dnd5/timoapi/global/analytics/event/ReflectionCreatedEvent.java
+++ b/src/main/java/com/dnd5/timoapi/global/analytics/event/ReflectionCreatedEvent.java
@@ -1,0 +1,6 @@
+package com.dnd5.timoapi.global.analytics.event;
+
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+
+public record ReflectionCreatedEvent(Long userId, Long reflectionId, Long questionId, ZtpiCategory category, int answerLength) {
+}

--- a/src/main/java/com/dnd5/timoapi/global/analytics/event/TestCompletedEvent.java
+++ b/src/main/java/com/dnd5/timoapi/global/analytics/event/TestCompletedEvent.java
@@ -1,0 +1,7 @@
+package com.dnd5.timoapi.global.analytics.event;
+
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+import java.util.Map;
+
+public record TestCompletedEvent(Long userId, Long testRecordId, Map<ZtpiCategory, Double> scores) {
+}

--- a/src/main/java/com/dnd5/timoapi/global/analytics/event/TestStartedEvent.java
+++ b/src/main/java/com/dnd5/timoapi/global/analytics/event/TestStartedEvent.java
@@ -1,0 +1,4 @@
+package com.dnd5.timoapi.global.analytics.event;
+
+public record TestStartedEvent(Long userId, Long testRecordId) {
+}

--- a/src/main/java/com/dnd5/timoapi/global/analytics/listener/AnalyticsEventListener.java
+++ b/src/main/java/com/dnd5/timoapi/global/analytics/listener/AnalyticsEventListener.java
@@ -1,0 +1,87 @@
+package com.dnd5.timoapi.global.analytics.listener;
+
+import com.dnd5.timoapi.global.analytics.domain.entity.AnalyticsEventEntity;
+import com.dnd5.timoapi.global.analytics.domain.repository.AnalyticsEventRepository;
+import com.dnd5.timoapi.global.analytics.event.FeedbackReceivedEvent;
+import com.dnd5.timoapi.global.analytics.event.NotificationSentEvent;
+import com.dnd5.timoapi.global.analytics.event.ReflectionCreatedEvent;
+import com.dnd5.timoapi.global.analytics.event.TestCompletedEvent;
+import com.dnd5.timoapi.global.analytics.event.TestStartedEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AnalyticsEventListener {
+
+    private final AnalyticsEventRepository analyticsEventRepository;
+    private final ObjectMapper objectMapper;
+
+    @Async("analyticsTaskExecutor")
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(TestStartedEvent e) {
+        save(e.userId(), "test_started", Map.of(
+                "testRecordId", e.testRecordId()
+        ));
+    }
+
+    @Async("analyticsTaskExecutor")
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(TestCompletedEvent e) {
+        save(e.userId(), "test_completed", Map.of(
+                "testRecordId", e.testRecordId(),
+                "scores", e.scores()
+        ));
+    }
+
+    @Async("analyticsTaskExecutor")
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(ReflectionCreatedEvent e) {
+        save(e.userId(), "reflection_created", Map.of(
+                "reflectionId", e.reflectionId(),
+                "questionId", e.questionId(),
+                "category", e.category().name(),
+                "answerLength", e.answerLength()
+        ));
+    }
+
+    @Async("analyticsTaskExecutor")
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(FeedbackReceivedEvent e) {
+        save(e.userId(), "feedback_received", Map.of(
+                "reflectionId", e.reflectionId(),
+                "score", e.score()
+        ));
+    }
+
+    @Async("analyticsTaskExecutor")
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(NotificationSentEvent e) {
+        save(e.userId(), "notification_sent", Map.of(
+                "tokenCount", e.tokenCount()
+        ));
+    }
+
+    private void save(Long userId, String eventName, Map<String, Object> properties) {
+        try {
+            String json = objectMapper.writeValueAsString(properties);
+            analyticsEventRepository.save(new AnalyticsEventEntity(userId, eventName, json));
+        } catch (JsonProcessingException ex) {
+            log.error("analytics_save_failed eventName={}", eventName, ex);
+        }
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/global/infrastructure/async/AsyncConfig.java
+++ b/src/main/java/com/dnd5/timoapi/global/infrastructure/async/AsyncConfig.java
@@ -12,6 +12,30 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 @Configuration
 public class AsyncConfig {
 
+    @Bean(name = "analyticsTaskExecutor")
+    public Executor analyticsTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("analytics-async-");
+        executor.setTaskDecorator(runnable -> {
+            Map<String, String> mdcContext = MDC.getCopyOfContextMap();
+            return () -> {
+                try {
+                    if (mdcContext != null) {
+                        MDC.setContextMap(mdcContext);
+                    }
+                    runnable.run();
+                } finally {
+                    MDC.clear();
+                }
+            };
+        });
+        executor.initialize();
+        return executor;
+    }
+
     @Bean(name = "feedbackTaskExecutor")
     public Executor feedbackTaskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();

--- a/src/main/java/com/dnd5/timoapi/global/infrastructure/gemini/GeminiClient.java
+++ b/src/main/java/com/dnd5/timoapi/global/infrastructure/gemini/GeminiClient.java
@@ -3,11 +3,13 @@ package com.dnd5.timoapi.global.infrastructure.gemini;
 import com.dnd5.timoapi.global.infrastructure.gemini.dto.GeminiRequest;
 import com.dnd5.timoapi.global.infrastructure.gemini.dto.GeminiResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class GeminiClient {
@@ -16,18 +18,28 @@ public class GeminiClient {
     private final GeminiProperties properties;
 
     public String generateContent(String systemPrompt, String userPrompt) {
+        log.info("gemini_request_start systemPromptLen={} userPromptLen={}", systemPrompt.length(), userPrompt.length());
+        long startMs = System.currentTimeMillis();
+
         GeminiRequest request = GeminiRequest.of(systemPrompt, userPrompt);
 
-        List<GeminiResponse> responses = geminiWebClient.post()
-                .uri("/publishers/google/models/{model}:streamGenerateContent?key={apiKey}",
-                        properties.model(), properties.apiKey())
-                .bodyValue(request)
-                .retrieve()
-                .bodyToFlux(GeminiResponse.class)
-                .collectList()
-                .block();
+        List<GeminiResponse> responses;
+        try {
+            responses = geminiWebClient.post()
+                    .uri("/publishers/google/models/{model}:streamGenerateContent?key={apiKey}",
+                            properties.model(), properties.apiKey())
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToFlux(GeminiResponse.class)
+                    .collectList()
+                    .block();
+        } catch (Exception e) {
+            log.error("gemini_request_failed reason=exception latencyMs={}", System.currentTimeMillis() - startMs, e);
+            throw e;
+        }
 
         if (responses == null || responses.isEmpty()) {
+            log.error("gemini_request_failed reason=empty_response latencyMs={}", System.currentTimeMillis() - startMs);
             throw new RuntimeException("Gemini API response is empty");
         }
 
@@ -41,6 +53,7 @@ public class GeminiClient {
             }
         }
 
+        log.info("gemini_request_done latencyMs={} responseLen={}", System.currentTimeMillis() - startMs, result.length());
         return result.toString();
     }
 }

--- a/src/main/java/com/dnd5/timoapi/global/log/ApiLoggingFilter.java
+++ b/src/main/java/com/dnd5/timoapi/global/log/ApiLoggingFilter.java
@@ -96,7 +96,7 @@ public class ApiLoggingFilter extends OncePerRequestFilter {
                 jsonLog = logData.toString();
             }
 
-            String apiType = request.getRequestURI().startsWith(ADMIN_PATH_PREFIX) ? "ADMIN" : "USER";
+            String apiType = request.getServletPath().startsWith(ADMIN_PATH_PREFIX) ? "ADMIN" : "USER";
             MDC.put("apiType", apiType);
 
             int status = wrappedResponse.getStatus();

--- a/src/main/java/com/dnd5/timoapi/global/log/ApiLoggingFilter.java
+++ b/src/main/java/com/dnd5/timoapi/global/log/ApiLoggingFilter.java
@@ -75,10 +75,12 @@ public class ApiLoggingFilter extends OncePerRequestFilter {
             Map<String, Object> logData = new HashMap<>();
             logData.put("method", request.getMethod());
             logData.put("uri", request.getRequestURI());
-            logData.put("queryString", request.getQueryString());
             logData.put("statusCode", wrappedResponse.getStatus());
             logData.put("duration", duration);
             logData.put("clientIp", request.getRemoteAddr());
+            if (request.getQueryString() != null) {
+                logData.put("queryString", request.getQueryString());
+            }
 
             if (!isSensitivePath(request.getServletPath())) {
                 logRequestBody(request, wrappedRequest, logData);

--- a/src/main/java/com/dnd5/timoapi/global/log/ApiLoggingFilter.java
+++ b/src/main/java/com/dnd5/timoapi/global/log/ApiLoggingFilter.java
@@ -94,10 +94,8 @@ public class ApiLoggingFilter extends OncePerRequestFilter {
 
             int status = wrappedResponse.getStatus();
             if (status >= 500) {
-                MDC.put("logType", "ERROR");
                 log.error(jsonLog);
             } else if (status >= 400) {
-                MDC.put("logType", "WARN");
                 log.warn(jsonLog);
             } else {
                 MDC.put("logType", "API");

--- a/src/main/java/com/dnd5/timoapi/global/log/ApiLoggingFilter.java
+++ b/src/main/java/com/dnd5/timoapi/global/log/ApiLoggingFilter.java
@@ -33,6 +33,8 @@ public class ApiLoggingFilter extends OncePerRequestFilter {
             "/auth/login", "/auth/callback", "/auth/reissue", "/test-auth/login"
     );
 
+    private static final String ADMIN_PATH_PREFIX = "/admin";
+
     private final ObjectMapper objectMapper;
 
     @Value("${logging.api.max-body-size:65536}")
@@ -93,6 +95,9 @@ public class ApiLoggingFilter extends OncePerRequestFilter {
             } catch (Exception e) {
                 jsonLog = logData.toString();
             }
+
+            String apiType = request.getRequestURI().startsWith(ADMIN_PATH_PREFIX) ? "ADMIN" : "USER";
+            MDC.put("apiType", apiType);
 
             int status = wrappedResponse.getStatus();
             if (status >= 500) {

--- a/src/main/java/com/dnd5/timoapi/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dnd5/timoapi/global/security/jwt/JwtAuthenticationFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.MDC;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -38,6 +39,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(userId, null, authorities);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
+                MDC.put("userId", userId.toString());
             } catch (BusinessException ignored) {
             }
         }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -18,22 +18,10 @@
     <reconnectionDelay>10 seconds</reconnectionDelay>
   </appender>
 
-  <appender name="LOGSTASH_ERROR" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-    <destination>${LOGSTASH_HOST}:${LOGSTASH_PORT}</destination>
-    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-      <level>ERROR</level>
-    </filter>
-    <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-      <customFields>{"service":"${APP_NAME}","logType":"ERROR"}</customFields>
-    </encoder>
-    <reconnectionDelay>10 seconds</reconnectionDelay>
-  </appender>
-
   <springProfile name="prod">
     <root level="INFO">
       <appender-ref ref="CONSOLE"/>
       <appender-ref ref="LOGSTASH"/>
-      <appender-ref ref="LOGSTASH_ERROR"/>
     </root>
   </springProfile>
 


### PR DESCRIPTION
## What is this PR? :mag:
- API 로그를 앱/어드민, 레벨(ERROR/WARN/API/APP) 기준으로 분리된 인덱스에 저장                                                                                                                         
- 요청 로그에 userId, traceId, apiType 등 컨텍스트 정보 자동 포함                                                                                                                                      

## Changes :memo:
- 단일 인덱스에 저장되었던 로그를 앱/어드민으로 추가 구분                                                                                                                                         
- 요청 로그에 userId 포함하여 사용자 추적 가능
 
## Screen Shot:
<img width="359" height="589" alt="스크린샷 2026-04-16 오전 4 07 58" src="https://github.com/user-attachments/assets/e2b50c4b-f73d-45bc-abd1-f743894bfd80" />

키바나 디스커버 데이터 뷰입니다!
로컬 환경에서 띄운 사진입니다. 머지 후에 서버 호스트에도 적용 예정입니다.

---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now emits analytics events for tests, reflections, feedback, and notifications to improve event tracking.
  * Notifications publish an event when sent.

* **Chores**
  * Enhanced request logging with request type and user identifiers; query strings logged only when present.
  * Logging pipeline and index routing updated; removed an error-specific log appender and added broader observability logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->