### PR TITLE
refactor/#56-ztpi-max-number

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/test/domain/entity/TestEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/domain/entity/TestEntity.java
@@ -50,12 +50,6 @@ public class TestEntity extends BaseEntity {
     }
 
     public int getMaxQuestionCount() {
-        if (getType() == TestType.ZTPI_15) {
-            return 15;
-        } else if (getType() == TestType.ZTPI_56) {
-            return 56;
-        } else {
-            return 0;
-        }
+        return getType().getMaxQuestionCount();
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/test/domain/entity/TestEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/domain/entity/TestEntity.java
@@ -50,6 +50,6 @@ public class TestEntity extends BaseEntity {
     }
 
     public int getMaxQuestionCount() {
-        return getType().getMaxQuestionCount();
+        return getType() != null ? getType().getMaxQuestionCount() : 0;
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/test/domain/model/enums/TestType.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/domain/model/enums/TestType.java
@@ -1,6 +1,16 @@
 package com.dnd5.timoapi.domain.test.domain.model.enums;
 
 public enum TestType {
-    ZTPI_15,
-    ZTPI_56,
+    ZTPI_15(15),
+    ZTPI_56(56);
+
+    private final int maxQuestionCount;
+
+    TestType(int maxQuestionCount) {
+        this.maxQuestionCount = maxQuestionCount;
+    }
+
+    public int getMaxQuestionCount() {
+        return maxQuestionCount;
+    }
 }


### PR DESCRIPTION
## What is this PR? :mag:
#56 이슈를 해결한 PR입니다.

## Changes :memo:
TestEntity.getMaxQuestionCount()가 if-else로 하드코딩되어 있어서, Enum field으로 변경했습니다.
(DB레벨에서보다는 이넘 레벨에서 관리하는 것이 낫다고 판단했습니다.)
- tests 테이블의 type 컬럼은 UNIQUE → TestType과 1:1 고정 매핑                                                                                                                                                             
- DB 방식은 런타임 에러 가능성 + 쿼리 추가 비용만 생김    

---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated maximum-question-count values into the test type definitions and simplified related logic.
  * Ensures a safe default (0) when a test type is unspecified, reducing errors and making behavior more predictable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnd-side-project/dnd-14th-5-backend/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->