### PR TITLE
#71-ideal-score-rename-and-unique-constraint

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/test/application/service/TimePerspectiveCategoryService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/application/service/TimePerspectiveCategoryService.java
@@ -42,7 +42,7 @@ public class TimePerspectiveCategoryService {
 
     public void update(@Positive Long categoryId, @Valid TimePerspectiveCategoryUpdateRequest request) {
         TimePerspectiveCategoryEntity timePerspectiveCategoryEntity = getTimePerspectiveCategoryEntity(categoryId);
-        timePerspectiveCategoryEntity.update(request.name(), request.englishName(), request.characterName(), request.personality(), request.description(), request.idealValue());
+        timePerspectiveCategoryEntity.update(request.name(), request.englishName(), request.characterName(), request.personality(), request.description(), request.idealScore());
     }
 
     public void delete(@Positive Long categoryId) {

--- a/src/main/java/com/dnd5/timoapi/domain/test/domain/entity/TimePerspectiveCategoryEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/domain/entity/TimePerspectiveCategoryEntity.java
@@ -17,10 +17,10 @@ import lombok.NoArgsConstructor;
 @Table(name = "time_perspective_categories")
 public class TimePerspectiveCategoryEntity extends BaseEntity {
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String name;
 
-    @Column(name = "english_name", nullable = false)
+    @Column(name = "english_name", nullable = false, unique = true)
     private String englishName;
 
     @Column(name = "character_name", nullable = false)
@@ -32,24 +32,24 @@ public class TimePerspectiveCategoryEntity extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String description;
 
-    @Column(name = "ideal_value", nullable = false)
-    private Double idealValue;
+    @Column(name = "ideal_score", nullable = false)
+    private Double idealScore;
 
     public static TimePerspectiveCategoryEntity from(TimePerspectiveCategory model) {
-        return new TimePerspectiveCategoryEntity(model.name(), model.englishName(), model.characterName(), model.personality(), model.description(), model.idealValue());
+        return new TimePerspectiveCategoryEntity(model.name(), model.englishName(), model.characterName(), model.personality(), model.description(), model.idealScore());
     }
 
     public TimePerspectiveCategory toModel() {
-        return new TimePerspectiveCategory(getId(), getName(), getEnglishName(), getCharacterName(), getPersonality(), getDescription(), getIdealValue(), getCreatedAt(), getUpdatedAt());
+        return new TimePerspectiveCategory(getId(), getName(), getEnglishName(), getCharacterName(), getPersonality(), getDescription(), getIdealScore(), getCreatedAt(), getUpdatedAt());
     }
 
-    public void update(String name, String englishName, String characterName, String personality, String description, Double idealValue) {
+    public void update(String name, String englishName, String characterName, String personality, String description, Double idealScore) {
         if (name != null) this.name = name;
         if (englishName != null) this.englishName = englishName;
         if (characterName != null) this.characterName = characterName;
         if (personality != null) this.personality = personality;
         if (description != null) this.description = description;
-        if (idealValue != null) this.idealValue = idealValue;
+        if (idealScore != null) this.idealScore = idealScore;
     }
 
 }

--- a/src/main/java/com/dnd5/timoapi/domain/test/domain/model/TimePerspectiveCategory.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/domain/model/TimePerspectiveCategory.java
@@ -9,7 +9,7 @@ public record TimePerspectiveCategory(
         String characterName,
         String personality,
         String description,
-        Double idealValue,
+        Double idealScore,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {

--- a/src/main/java/com/dnd5/timoapi/domain/test/presentation/request/TimePerspectiveCategoryCreateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/presentation/request/TimePerspectiveCategoryCreateRequest.java
@@ -11,9 +11,9 @@ public record TimePerspectiveCategoryCreateRequest(
         String personality,
         @NotBlank
         String description,
-        Double idealValue
+        Double idealScore
 ) {
     public TimePerspectiveCategory toModel() {
-        return TimePerspectiveCategory.create(name, englishName, characterName, personality, description, idealValue);
+        return TimePerspectiveCategory.create(name, englishName, characterName, personality, description, idealScore);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/test/presentation/request/TimePerspectiveCategoryUpdateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/presentation/request/TimePerspectiveCategoryUpdateRequest.java
@@ -10,6 +10,6 @@ public record TimePerspectiveCategoryUpdateRequest(
         String personality,
         @NotBlank
         String description,
-        Double idealValue
+        Double idealScore
 ) {
 }

--- a/src/main/java/com/dnd5/timoapi/domain/test/presentation/response/TimePerspectiveCategoryDetailResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/presentation/response/TimePerspectiveCategoryDetailResponse.java
@@ -10,7 +10,7 @@ public record TimePerspectiveCategoryDetailResponse(
         String characterName,
         String personality,
         String description,
-        Double idealValue,
+        Double idealScore,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -22,7 +22,7 @@ public record TimePerspectiveCategoryDetailResponse(
                 model.characterName(),
                 model.personality(),
                 model.description(),
-                model.idealValue(),
+                model.idealScore(),
                 model.createdAt(),
                 model.updatedAt()
         );

--- a/src/main/java/com/dnd5/timoapi/domain/test/presentation/response/TimePerspectiveCategoryResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/presentation/response/TimePerspectiveCategoryResponse.java
@@ -10,7 +10,7 @@ public record TimePerspectiveCategoryResponse(
         String characterName,
         String personality,
         String description,
-        Double idealValue,
+        Double idealScore,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -22,7 +22,7 @@ public record TimePerspectiveCategoryResponse(
                 model.characterName(),
                 model.personality(),
                 model.description(),
-                model.idealValue(),
+                model.idealScore(),
                 model.createdAt(),
                 model.updatedAt()
         );


### PR DESCRIPTION
## What is this PR? :mag:
#71 이슈를 해결한 PR입니다.

## Changes :memo:
idealValue를 idealScore로 rename 및 name/english_name UNIQUE 제약 추가

Merge 전 데이터베이스에서 이름을 변경하는 작업을 수행해야 합니다
```
ALTER TABLE time_perspective_categories RENAME COLUMN ideal_value TO ideal_score;
ALTER TABLE time_perspective_categories ADD CONSTRAINT uq_name UNIQUE (name);
ALTER TABLE time_perspective_categories ADD CONSTRAINT uq_english_name UNIQUE (english_name);
```

---
### Check List
- [ ] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed field `idealValue` to `idealScore` across API requests and responses for time perspective categories.

* **Bug Fixes**
  * Added unique constraints to category name fields to prevent duplicate entries in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->