### PR TITLE
feat: 그룹 회고 도메인 구현

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupService.java
@@ -5,6 +5,8 @@ import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberEntity;
 import com.dnd5.timoapi.domain.group.domain.model.Group;
 import com.dnd5.timoapi.domain.group.domain.model.GroupMember;
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupMemberRole;
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupReflectionSort;
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
 import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberRepository;
 import com.dnd5.timoapi.domain.group.domain.repository.GroupRepository;
 import com.dnd5.timoapi.domain.group.exception.GroupErrorCode;
@@ -13,14 +15,25 @@ import com.dnd5.timoapi.domain.group.presentation.request.GroupUpdateRequest;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupCreateResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupSummaryResponse;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupTodayReflectionItem;
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionQuestionEntity;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionQuestionRepository;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
+import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
+import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
 import com.dnd5.timoapi.global.exception.BusinessException;
 import com.dnd5.timoapi.global.security.context.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -29,11 +42,15 @@ public class GroupService {
 
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
+    private final ReflectionRepository reflectionRepository;
+    private final ReflectionQuestionRepository reflectionQuestionRepository;
+    private final UserRepository userRepository;
 
     public GroupCreateResponse createGroup(GroupCreateRequest request) {
+        validateCategoryForType(request.type(), request.category() != null);
         Long userId = SecurityUtil.getCurrentUserId();
         String code = generateUniqueCode();
-        Group group = Group.create(code, request.name(), request.type(), request.image());
+        Group group = Group.create(code, request.name(), request.type(), request.image(), request.category());
         GroupEntity savedGroup = groupRepository.save(GroupEntity.from(group));
         GroupMember ownerMember = GroupMember.create(savedGroup.getId(), userId, GroupMemberRole.OWNER);
         groupMemberRepository.save(GroupMemberEntity.from(ownerMember));
@@ -130,6 +147,74 @@ public class GroupService {
         }
     }
 
+    @Transactional(readOnly = true)
+    public List<GroupTodayReflectionItem> getTodayReflections(Long groupId, GroupReflectionSort sort) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        GroupEntity groupEntity = getGroupEntity(groupId);
+        LocalDate today = LocalDate.now();
+
+        List<ReflectionEntity> reflections;
+
+        if (groupEntity.getType() == GroupType.CHARACTER) {
+            reflections = reflectionRepository.findAllByDateAndQuestionCategory(today, groupEntity.getCategory());
+        } else {
+            List<Long> memberUserIds = groupMemberRepository.findAllByGroupIdAndDeletedAtIsNull(groupId)
+                    .stream()
+                    .map(GroupMemberEntity::getUserId)
+                    .toList();
+
+            if (!groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)) {
+                throw new BusinessException(GroupErrorCode.GROUP_ACCESS_DENIED);
+            }
+
+            if (memberUserIds.isEmpty()) {
+                return List.of();
+            }
+            reflections = reflectionRepository.findAllByDateAndUserIdIn(today, memberUserIds);
+        }
+
+        if (reflections.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> questionIds = reflections.stream().map(ReflectionEntity::getQuestionId).distinct().toList();
+        List<Long> userIds = reflections.stream().map(ReflectionEntity::getUserId).distinct().toList();
+
+        Map<Long, ReflectionQuestionEntity> questionMap = reflectionQuestionRepository.findAllById(questionIds)
+                .stream().collect(Collectors.toMap(q -> q.getId(), q -> q));
+        Map<Long, UserEntity> userMap = userRepository.findAllById(userIds)
+                .stream().collect(Collectors.toMap(u -> u.getId(), u -> u));
+
+        Comparator<ReflectionEntity> comparator = switch (sort) {
+            case STREAK -> Comparator.comparingInt((ReflectionEntity r) -> {
+                UserEntity u = userMap.get(r.getUserId());
+                return u != null ? u.getStreakDays() : 0;
+            }).reversed();
+            case TOTAL -> Comparator.comparingInt((ReflectionEntity r) -> {
+                UserEntity u = userMap.get(r.getUserId());
+                return u != null ? u.getTotalDays() : 0;
+            }).reversed();
+            default -> Comparator.comparing(ReflectionEntity::getCreatedAt, Comparator.reverseOrder());
+        };
+
+        return reflections.stream()
+                .sorted(comparator)
+                .map(r -> {
+                    ReflectionQuestionEntity question = questionMap.get(r.getQuestionId());
+                    UserEntity user = userMap.get(r.getUserId());
+                    return new GroupTodayReflectionItem(
+                            r.getUserId(),
+                            user != null ? user.getNickname() : null,
+                            question != null ? question.getContent() : null,
+                            question != null ? question.getCategory() : null,
+                            r.getAnswerText(),
+                            user != null ? user.getStreakDays() : 0,
+                            user != null ? user.getTotalDays() : 0
+                    );
+                })
+                .toList();
+    }
+
     private void handleOwnerLeave(Long groupId, GroupMemberEntity ownerMember) {
         long count = groupMemberRepository.countByGroupIdAndDeletedAtIsNull(groupId);
         if (count == 1) {
@@ -140,6 +225,15 @@ public class GroupService {
                     .findTopByGroupIdAndRoleAndDeletedAtIsNullOrderByCreatedAtAsc(groupId, GroupMemberRole.MEMBER)
                     .ifPresent(GroupMemberEntity::promoteToOwner);
             ownerMember.softDelete();
+        }
+    }
+
+    private void validateCategoryForType(GroupType type, boolean hasCategory) {
+        if (type == GroupType.CHARACTER && !hasCategory) {
+            throw new BusinessException(GroupErrorCode.GROUP_INVALID_CATEGORY);
+        }
+        if (type == GroupType.FRIEND && hasCategory) {
+            throw new BusinessException(GroupErrorCode.GROUP_INVALID_CATEGORY);
         }
     }
 

--- a/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupService.java
@@ -1,0 +1,169 @@
+package com.dnd5.timoapi.domain.group.application.service;
+
+import com.dnd5.timoapi.domain.group.domain.entity.GroupEntity;
+import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberEntity;
+import com.dnd5.timoapi.domain.group.domain.model.Group;
+import com.dnd5.timoapi.domain.group.domain.model.GroupMember;
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupMemberRole;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberRepository;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupRepository;
+import com.dnd5.timoapi.domain.group.exception.GroupErrorCode;
+import com.dnd5.timoapi.domain.group.presentation.request.GroupCreateRequest;
+import com.dnd5.timoapi.domain.group.presentation.request.GroupUpdateRequest;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupCreateResponse;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupResponse;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupSummaryResponse;
+import com.dnd5.timoapi.global.exception.BusinessException;
+import com.dnd5.timoapi.global.security.context.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GroupService {
+
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+
+    public GroupCreateResponse createGroup(GroupCreateRequest request) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        String code = generateUniqueCode();
+        Group group = Group.create(code, request.name(), request.type(), request.image());
+        GroupEntity savedGroup = groupRepository.save(GroupEntity.from(group));
+        GroupMember ownerMember = GroupMember.create(savedGroup.getId(), userId, GroupMemberRole.OWNER);
+        groupMemberRepository.save(GroupMemberEntity.from(ownerMember));
+        return GroupCreateResponse.from(savedGroup.toModel());
+    }
+
+    @Transactional(readOnly = true)
+    public List<GroupSummaryResponse> getMyGroups() {
+        Long userId = SecurityUtil.getCurrentUserId();
+        List<GroupMemberEntity> myMemberships = groupMemberRepository.findAllByUserIdAndDeletedAtIsNull(userId);
+        return myMemberships.stream()
+                .map(member -> {
+                    GroupEntity groupEntity = getGroupEntity(member.getGroupId());
+                    int memberCount = (int) groupMemberRepository.countByGroupIdAndDeletedAtIsNull(groupEntity.getId());
+                    return GroupSummaryResponse.of(groupEntity.toModel(), memberCount, member.getRole());
+                })
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public GroupResponse getGroup(Long groupId, String code) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        GroupEntity groupEntity = getGroupEntity(groupId);
+
+        boolean isMember = groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId);
+        GroupMemberRole myRole = null;
+
+        if (code != null) {
+            if (!groupEntity.getCode().equals(code)) {
+                throw new BusinessException(GroupErrorCode.GROUP_ACCESS_DENIED);
+            }
+            if (isMember) {
+                myRole = groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)
+                        .map(GroupMemberEntity::getRole)
+                        .orElse(null);
+            }
+        } else {
+            if (!isMember) {
+                throw new BusinessException(GroupErrorCode.GROUP_ACCESS_DENIED);
+            }
+            myRole = groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)
+                    .map(GroupMemberEntity::getRole)
+                    .orElse(null);
+        }
+
+        int memberCount = (int) groupMemberRepository.countByGroupIdAndDeletedAtIsNull(groupId);
+        return GroupResponse.of(groupEntity.toModel(), memberCount, isMember, myRole);
+    }
+
+    public void updateGroup(Long groupId, GroupUpdateRequest request) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        GroupMemberEntity member = getGroupMember(groupId, userId);
+        assertOwner(member);
+        GroupEntity groupEntity = getGroupEntity(groupId);
+        groupEntity.update(request.name(), request.image());
+    }
+
+    public void deleteGroup(Long groupId) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        GroupMemberEntity member = getGroupMember(groupId, userId);
+        assertOwner(member);
+        GroupEntity groupEntity = getGroupEntity(groupId);
+        groupMemberRepository.findAllByGroupIdAndDeletedAtIsNull(groupId).forEach(GroupMemberEntity::softDelete);
+        groupEntity.softDelete();
+    }
+
+    public void joinGroup(Long groupId) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        getGroupEntity(groupId);
+
+        if (groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)) {
+            throw new BusinessException(GroupErrorCode.GROUP_ALREADY_JOINED);
+        }
+
+        groupMemberRepository.findByGroupIdAndUserId(groupId, userId)
+                .ifPresentOrElse(
+                        existing -> {
+                            existing.restore();
+                        },
+                        () -> groupMemberRepository.save(
+                                GroupMemberEntity.from(GroupMember.create(groupId, userId, GroupMemberRole.MEMBER))
+                        )
+                );
+    }
+
+    public void leaveGroup(Long groupId) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        GroupMemberEntity member = getGroupMember(groupId, userId);
+
+        if (member.getRole() == GroupMemberRole.OWNER) {
+            handleOwnerLeave(groupId, member);
+        } else {
+            member.softDelete();
+        }
+    }
+
+    private void handleOwnerLeave(Long groupId, GroupMemberEntity ownerMember) {
+        long count = groupMemberRepository.countByGroupIdAndDeletedAtIsNull(groupId);
+        if (count == 1) {
+            getGroupEntity(groupId).softDelete();
+            ownerMember.softDelete();
+        } else {
+            groupMemberRepository
+                    .findTopByGroupIdAndRoleAndDeletedAtIsNullOrderByCreatedAtAsc(groupId, GroupMemberRole.MEMBER)
+                    .ifPresent(GroupMemberEntity::promoteToOwner);
+            ownerMember.softDelete();
+        }
+    }
+
+    private GroupEntity getGroupEntity(Long groupId) {
+        return groupRepository.findByIdAndDeletedAtIsNull(groupId)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.GROUP_NOT_FOUND));
+    }
+
+    private GroupMemberEntity getGroupMember(Long groupId, Long userId) {
+        return groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.GROUP_MEMBER_NOT_FOUND));
+    }
+
+    private void assertOwner(GroupMemberEntity member) {
+        if (member.getRole() != GroupMemberRole.OWNER) {
+            throw new BusinessException(GroupErrorCode.GROUP_FORBIDDEN);
+        }
+    }
+
+    private String generateUniqueCode() {
+        String code;
+        do {
+            code = UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase();
+        } while (groupRepository.existsByCodeAndDeletedAtIsNull(code));
+        return code;
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupService.java
@@ -13,8 +13,8 @@ import com.dnd5.timoapi.domain.group.exception.GroupErrorCode;
 import com.dnd5.timoapi.domain.group.presentation.request.GroupCreateRequest;
 import com.dnd5.timoapi.domain.group.presentation.request.GroupUpdateRequest;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupCreateResponse;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupDetailResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupResponse;
-import com.dnd5.timoapi.domain.group.presentation.response.GroupSummaryResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupTodayReflectionItem;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionQuestionEntity;
@@ -58,20 +58,20 @@ public class GroupService {
     }
 
     @Transactional(readOnly = true)
-    public List<GroupSummaryResponse> getMyGroups() {
+    public List<GroupResponse> getMyGroups() {
         Long userId = SecurityUtil.getCurrentUserId();
         List<GroupMemberEntity> myMemberships = groupMemberRepository.findAllByUserIdAndDeletedAtIsNull(userId);
         return myMemberships.stream()
                 .map(member -> {
                     GroupEntity groupEntity = getGroupEntity(member.getGroupId());
                     int memberCount = (int) groupMemberRepository.countByGroupIdAndDeletedAtIsNull(groupEntity.getId());
-                    return GroupSummaryResponse.of(groupEntity.toModel(), memberCount, member.getRole());
+                    return GroupResponse.of(groupEntity.toModel(), memberCount, member.getRole());
                 })
                 .toList();
     }
 
     @Transactional(readOnly = true)
-    public GroupResponse getGroup(Long groupId, String code) {
+    public GroupDetailResponse getGroup(Long groupId, String code) {
         Long userId = SecurityUtil.getCurrentUserId();
         GroupEntity groupEntity = getGroupEntity(groupId);
 
@@ -97,7 +97,7 @@ public class GroupService {
         }
 
         int memberCount = (int) groupMemberRepository.countByGroupIdAndDeletedAtIsNull(groupId);
-        return GroupResponse.of(groupEntity.toModel(), memberCount, isMember, myRole);
+        return GroupDetailResponse.of(groupEntity.toModel(), memberCount, isMember, myRole);
     }
 
     public void updateGroup(Long groupId, GroupUpdateRequest request) {

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/entity/GroupEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/entity/GroupEntity.java
@@ -2,6 +2,7 @@ package com.dnd5.timoapi.domain.group.domain.entity;
 
 import com.dnd5.timoapi.domain.group.domain.model.Group;
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import com.dnd5.timoapi.global.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -33,12 +34,16 @@ public class GroupEntity extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String image;
 
+    @Column
+    @Enumerated(EnumType.STRING)
+    private ZtpiCategory category;
+
     public static GroupEntity from(Group model) {
-        return new GroupEntity(model.code(), model.name(), model.type(), model.image());
+        return new GroupEntity(model.code(), model.name(), model.type(), model.image(), model.category());
     }
 
     public Group toModel() {
-        return new Group(getId(), code, name, type, image, getCreatedAt(), getUpdatedAt());
+        return new Group(getId(), code, name, type, image, category, getCreatedAt(), getUpdatedAt());
     }
 
     public void update(String name, String image) {

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/entity/GroupEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/entity/GroupEntity.java
@@ -1,0 +1,48 @@
+package com.dnd5.timoapi.domain.group.domain.entity;
+
+import com.dnd5.timoapi.domain.group.domain.model.Group;
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
+import com.dnd5.timoapi.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(name = "groups")
+public class GroupEntity extends BaseEntity {
+
+    @Column(nullable = false, unique = true)
+    private String code;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private GroupType type;
+
+    @Column(columnDefinition = "TEXT")
+    private String image;
+
+    public static GroupEntity from(Group model) {
+        return new GroupEntity(model.code(), model.name(), model.type(), model.image());
+    }
+
+    public Group toModel() {
+        return new Group(getId(), code, name, type, image, getCreatedAt(), getUpdatedAt());
+    }
+
+    public void update(String name, String image) {
+        if (name != null) this.name = name;
+        if (image != null) this.image = image;
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/entity/GroupMemberEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/entity/GroupMemberEntity.java
@@ -1,0 +1,48 @@
+package com.dnd5.timoapi.domain.group.domain.entity;
+
+import com.dnd5.timoapi.domain.group.domain.model.GroupMember;
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupMemberRole;
+import com.dnd5.timoapi.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(
+        name = "group_members",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"group_id", "user_id"})
+)
+public class GroupMemberEntity extends BaseEntity {
+
+    @Column(name = "group_id", nullable = false)
+    private Long groupId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private GroupMemberRole role;
+
+    public static GroupMemberEntity from(GroupMember model) {
+        return new GroupMemberEntity(model.groupId(), model.userId(), model.role());
+    }
+
+    public GroupMember toModel() {
+        return new GroupMember(getId(), groupId, userId, role, getCreatedAt(), getUpdatedAt());
+    }
+
+    public void promoteToOwner() {
+        this.role = GroupMemberRole.OWNER;
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/model/Group.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/model/Group.java
@@ -1,0 +1,19 @@
+package com.dnd5.timoapi.domain.group.domain.model;
+
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
+
+import java.time.LocalDateTime;
+
+public record Group(
+        Long id,
+        String code,
+        String name,
+        GroupType type,
+        String image,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static Group create(String code, String name, GroupType type, String image) {
+        return new Group(null, code, name, type, image, null, null);
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/model/Group.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/model/Group.java
@@ -1,6 +1,7 @@
 package com.dnd5.timoapi.domain.group.domain.model;
 
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 
 import java.time.LocalDateTime;
 
@@ -10,10 +11,11 @@ public record Group(
         String name,
         GroupType type,
         String image,
+        ZtpiCategory category,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
-    public static Group create(String code, String name, GroupType type, String image) {
-        return new Group(null, code, name, type, image, null, null);
+    public static Group create(String code, String name, GroupType type, String image, ZtpiCategory category) {
+        return new Group(null, code, name, type, image, category, null, null);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/model/GroupMember.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/model/GroupMember.java
@@ -1,0 +1,18 @@
+package com.dnd5.timoapi.domain.group.domain.model;
+
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupMemberRole;
+
+import java.time.LocalDateTime;
+
+public record GroupMember(
+        Long id,
+        Long groupId,
+        Long userId,
+        GroupMemberRole role,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static GroupMember create(Long groupId, Long userId, GroupMemberRole role) {
+        return new GroupMember(null, groupId, userId, role, null, null);
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/model/enums/GroupMemberRole.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/model/enums/GroupMemberRole.java
@@ -1,0 +1,6 @@
+package com.dnd5.timoapi.domain.group.domain.model.enums;
+
+public enum GroupMemberRole {
+    OWNER,
+    MEMBER
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/model/enums/GroupReflectionSort.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/model/enums/GroupReflectionSort.java
@@ -1,0 +1,7 @@
+package com.dnd5.timoapi.domain.group.domain.model.enums;
+
+public enum GroupReflectionSort {
+    LATEST,
+    STREAK,
+    TOTAL
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/model/enums/GroupType.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/model/enums/GroupType.java
@@ -1,0 +1,6 @@
+package com.dnd5.timoapi.domain.group.domain.model.enums;
+
+public enum GroupType {
+    FRIEND,
+    CHARACTER
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupMemberRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupMemberRepository.java
@@ -1,0 +1,25 @@
+package com.dnd5.timoapi.domain.group.domain.repository;
+
+import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberEntity;
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupMemberRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GroupMemberRepository extends JpaRepository<GroupMemberEntity, Long> {
+
+    Optional<GroupMemberEntity> findByGroupIdAndUserIdAndDeletedAtIsNull(Long groupId, Long userId);
+
+    Optional<GroupMemberEntity> findByGroupIdAndUserId(Long groupId, Long userId);
+
+    List<GroupMemberEntity> findAllByGroupIdAndDeletedAtIsNull(Long groupId);
+
+    List<GroupMemberEntity> findAllByUserIdAndDeletedAtIsNull(Long userId);
+
+    boolean existsByGroupIdAndUserIdAndDeletedAtIsNull(Long groupId, Long userId);
+
+    long countByGroupIdAndDeletedAtIsNull(Long groupId);
+
+    Optional<GroupMemberEntity> findTopByGroupIdAndRoleAndDeletedAtIsNullOrderByCreatedAtAsc(Long groupId, GroupMemberRole role);
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupRepository.java
@@ -1,0 +1,13 @@
+package com.dnd5.timoapi.domain.group.domain.repository;
+
+import com.dnd5.timoapi.domain.group.domain.entity.GroupEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface GroupRepository extends JpaRepository<GroupEntity, Long> {
+
+    Optional<GroupEntity> findByIdAndDeletedAtIsNull(Long id);
+
+    boolean existsByCodeAndDeletedAtIsNull(String code);
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/exception/GroupErrorCode.java
@@ -14,6 +14,7 @@ public enum GroupErrorCode implements ErrorCode {
     GROUP_ALREADY_JOINED(HttpStatus.CONFLICT, "이미 참여한 그룹입니다."),
     GROUP_FORBIDDEN(HttpStatus.FORBIDDEN, "그룹 관리 권한이 없습니다."),
     GROUP_ACCESS_DENIED(HttpStatus.FORBIDDEN, "그룹에 접근할 권한이 없습니다."),
+    GROUP_INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "캐릭터 그룹에는 ZTPI 캐릭터를 지정해야 합니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/dnd5/timoapi/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/exception/GroupErrorCode.java
@@ -1,0 +1,21 @@
+package com.dnd5.timoapi.domain.group.exception;
+
+import com.dnd5.timoapi.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GroupErrorCode implements ErrorCode {
+
+    GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "그룹을 찾을 수 없습니다."),
+    GROUP_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "그룹 멤버를 찾을 수 없습니다."),
+    GROUP_ALREADY_JOINED(HttpStatus.CONFLICT, "이미 참여한 그룹입니다."),
+    GROUP_FORBIDDEN(HttpStatus.FORBIDDEN, "그룹 관리 권한이 없습니다."),
+    GROUP_ACCESS_DENIED(HttpStatus.FORBIDDEN, "그룹에 접근할 권한이 없습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/GroupController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/GroupController.java
@@ -4,8 +4,8 @@ import com.dnd5.timoapi.domain.group.application.service.GroupService;
 import com.dnd5.timoapi.domain.group.presentation.request.GroupCreateRequest;
 import com.dnd5.timoapi.domain.group.presentation.request.GroupUpdateRequest;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupCreateResponse;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupDetailResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupResponse;
-import com.dnd5.timoapi.domain.group.presentation.response.GroupSummaryResponse;
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupReflectionSort;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupTodayReflectionItem;
 import jakarta.validation.Valid;
@@ -32,12 +32,12 @@ public class GroupController {
     }
 
     @GetMapping
-    public List<GroupSummaryResponse> getMyGroups() {
+    public List<GroupResponse> getMyGroups() {
         return groupService.getMyGroups();
     }
 
     @GetMapping("/{groupId}")
-    public GroupResponse getGroup(
+    public GroupDetailResponse getGroup(
             @Positive @PathVariable Long groupId,
             @RequestParam(required = false) String code) {
         return groupService.getGroup(groupId, code);

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/GroupController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/GroupController.java
@@ -1,0 +1,69 @@
+package com.dnd5.timoapi.domain.group.presentation;
+
+import com.dnd5.timoapi.domain.group.application.service.GroupService;
+import com.dnd5.timoapi.domain.group.presentation.request.GroupCreateRequest;
+import com.dnd5.timoapi.domain.group.presentation.request.GroupUpdateRequest;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupCreateResponse;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupResponse;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupSummaryResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/groups")
+@RequiredArgsConstructor
+@Validated
+public class GroupController {
+
+    private final GroupService groupService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public GroupCreateResponse createGroup(@Valid @RequestBody GroupCreateRequest request) {
+        return groupService.createGroup(request);
+    }
+
+    @GetMapping
+    public List<GroupSummaryResponse> getMyGroups() {
+        return groupService.getMyGroups();
+    }
+
+    @GetMapping("/{groupId}")
+    public GroupResponse getGroup(
+            @Positive @PathVariable Long groupId,
+            @RequestParam(required = false) String code) {
+        return groupService.getGroup(groupId, code);
+    }
+
+    @PatchMapping("/{groupId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateGroup(
+            @Positive @PathVariable Long groupId,
+            @Valid @RequestBody GroupUpdateRequest request) {
+        groupService.updateGroup(groupId, request);
+    }
+
+    @DeleteMapping("/{groupId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteGroup(@Positive @PathVariable Long groupId) {
+        groupService.deleteGroup(groupId);
+    }
+
+    @PostMapping("/{groupId}/members")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void joinGroup(@Positive @PathVariable Long groupId) {
+        groupService.joinGroup(groupId);
+    }
+
+    @DeleteMapping("/{groupId}/members")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void leaveGroup(@Positive @PathVariable Long groupId) {
+        groupService.leaveGroup(groupId);
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/GroupController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/GroupController.java
@@ -6,6 +6,8 @@ import com.dnd5.timoapi.domain.group.presentation.request.GroupUpdateRequest;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupCreateResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupSummaryResponse;
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupReflectionSort;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupTodayReflectionItem;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
@@ -65,5 +67,12 @@ public class GroupController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void leaveGroup(@Positive @PathVariable Long groupId) {
         groupService.leaveGroup(groupId);
+    }
+
+    @GetMapping("/{groupId}/reflections/today")
+    public List<GroupTodayReflectionItem> getTodayReflections(
+            @Positive @PathVariable Long groupId,
+            @RequestParam(defaultValue = "LATEST") GroupReflectionSort sort) {
+        return groupService.getTodayReflections(groupId, sort);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/request/GroupCreateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/request/GroupCreateRequest.java
@@ -1,0 +1,12 @@
+package com.dnd5.timoapi.domain.group.presentation.request;
+
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record GroupCreateRequest(
+        @NotBlank String name,
+        @NotNull GroupType type,
+        String image
+) {
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/request/GroupCreateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/request/GroupCreateRequest.java
@@ -1,12 +1,14 @@
 package com.dnd5.timoapi.domain.group.presentation.request;
 
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record GroupCreateRequest(
         @NotBlank String name,
         @NotNull GroupType type,
-        String image
+        String image,
+        ZtpiCategory category
 ) {
 }

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/request/GroupUpdateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/request/GroupUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.dnd5.timoapi.domain.group.presentation.request;
+
+public record GroupUpdateRequest(
+        String name,
+        String image
+) {
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupCreateResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupCreateResponse.java
@@ -1,0 +1,12 @@
+package com.dnd5.timoapi.domain.group.presentation.response;
+
+import com.dnd5.timoapi.domain.group.domain.model.Group;
+
+public record GroupCreateResponse(
+        Long id,
+        String code
+) {
+    public static GroupCreateResponse from(Group model) {
+        return new GroupCreateResponse(model.id(), model.code());
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupDetailResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupDetailResponse.java
@@ -7,24 +7,28 @@ import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 
 import java.time.LocalDateTime;
 
-public record GroupSummaryResponse(
+public record GroupDetailResponse(
         Long id,
+        String code,
         String name,
         GroupType type,
         String image,
         ZtpiCategory category,
         int memberCount,
+        Boolean isMember,
         GroupMemberRole myRole,
         LocalDateTime createdAt
 ) {
-    public static GroupSummaryResponse of(Group group, int memberCount, GroupMemberRole myRole) {
-        return new GroupSummaryResponse(
+    public static GroupDetailResponse of(Group group, int memberCount, Boolean isMember, GroupMemberRole myRole) {
+        return new GroupDetailResponse(
                 group.id(),
+                group.code(),
                 group.name(),
                 group.type(),
                 group.image(),
                 group.category(),
                 memberCount,
+                isMember,
                 myRole,
                 group.createdAt()
         );

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupResponse.java
@@ -9,26 +9,22 @@ import java.time.LocalDateTime;
 
 public record GroupResponse(
         Long id,
-        String code,
         String name,
         GroupType type,
         String image,
         ZtpiCategory category,
         int memberCount,
-        Boolean isMember,
         GroupMemberRole myRole,
         LocalDateTime createdAt
 ) {
-    public static GroupResponse of(Group group, int memberCount, Boolean isMember, GroupMemberRole myRole) {
+    public static GroupResponse of(Group group, int memberCount, GroupMemberRole myRole) {
         return new GroupResponse(
                 group.id(),
-                group.code(),
                 group.name(),
                 group.type(),
                 group.image(),
                 group.category(),
                 memberCount,
-                isMember,
                 myRole,
                 group.createdAt()
         );

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupResponse.java
@@ -1,0 +1,33 @@
+package com.dnd5.timoapi.domain.group.presentation.response;
+
+import com.dnd5.timoapi.domain.group.domain.model.Group;
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupMemberRole;
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
+
+import java.time.LocalDateTime;
+
+public record GroupResponse(
+        Long id,
+        String code,
+        String name,
+        GroupType type,
+        String image,
+        int memberCount,
+        Boolean isMember,
+        GroupMemberRole myRole,
+        LocalDateTime createdAt
+) {
+    public static GroupResponse of(Group group, int memberCount, Boolean isMember, GroupMemberRole myRole) {
+        return new GroupResponse(
+                group.id(),
+                group.code(),
+                group.name(),
+                group.type(),
+                group.image(),
+                memberCount,
+                isMember,
+                myRole,
+                group.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupResponse.java
@@ -3,6 +3,7 @@ package com.dnd5.timoapi.domain.group.presentation.response;
 import com.dnd5.timoapi.domain.group.domain.model.Group;
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupMemberRole;
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 
 import java.time.LocalDateTime;
 
@@ -12,6 +13,7 @@ public record GroupResponse(
         String name,
         GroupType type,
         String image,
+        ZtpiCategory category,
         int memberCount,
         Boolean isMember,
         GroupMemberRole myRole,
@@ -24,6 +26,7 @@ public record GroupResponse(
                 group.name(),
                 group.type(),
                 group.image(),
+                group.category(),
                 memberCount,
                 isMember,
                 myRole,

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupSummaryResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupSummaryResponse.java
@@ -3,6 +3,7 @@ package com.dnd5.timoapi.domain.group.presentation.response;
 import com.dnd5.timoapi.domain.group.domain.model.Group;
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupMemberRole;
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 
 import java.time.LocalDateTime;
 
@@ -11,6 +12,7 @@ public record GroupSummaryResponse(
         String name,
         GroupType type,
         String image,
+        ZtpiCategory category,
         int memberCount,
         GroupMemberRole myRole,
         LocalDateTime createdAt
@@ -21,6 +23,7 @@ public record GroupSummaryResponse(
                 group.name(),
                 group.type(),
                 group.image(),
+                group.category(),
                 memberCount,
                 myRole,
                 group.createdAt()

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupSummaryResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupSummaryResponse.java
@@ -1,0 +1,29 @@
+package com.dnd5.timoapi.domain.group.presentation.response;
+
+import com.dnd5.timoapi.domain.group.domain.model.Group;
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupMemberRole;
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
+
+import java.time.LocalDateTime;
+
+public record GroupSummaryResponse(
+        Long id,
+        String name,
+        GroupType type,
+        String image,
+        int memberCount,
+        GroupMemberRole myRole,
+        LocalDateTime createdAt
+) {
+    public static GroupSummaryResponse of(Group group, int memberCount, GroupMemberRole myRole) {
+        return new GroupSummaryResponse(
+                group.id(),
+                group.name(),
+                group.type(),
+                group.image(),
+                memberCount,
+                myRole,
+                group.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupTodayReflectionItem.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupTodayReflectionItem.java
@@ -1,0 +1,14 @@
+package com.dnd5.timoapi.domain.group.presentation.response;
+
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+
+public record GroupTodayReflectionItem(
+        Long userId,
+        String nickname,
+        String questionContent,
+        ZtpiCategory questionCategory,
+        String answerText,
+        Integer streakDays,
+        Integer totalDays
+) {
+}

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionService.java
@@ -75,6 +75,7 @@ public class ReflectionService {
 
         boolean wroteYesterday = isWroteYesterday(userId);
         userEntity.updateStreak(wroteYesterday);
+        userEntity.incrementTotalDays();
 
         return new ReflectionCreateResponse(saved.getId());
     }

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/domain/repository/ReflectionRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/domain/repository/ReflectionRepository.java
@@ -1,6 +1,7 @@
 package com.dnd5.timoapi.domain.reflection.domain.repository;
 
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -28,4 +29,29 @@ public interface ReflectionRepository extends JpaRepository<ReflectionEntity, Lo
 
     List<ReflectionEntity> findAllByUserIdAndDateBetween(Long userId, LocalDate start,
             LocalDate end);
+
+    @Query("""
+            SELECT r
+            FROM ReflectionEntity r
+            JOIN ReflectionQuestionEntity q ON r.questionId = q.id
+            WHERE r.date = :date
+              AND q.category = :category
+              AND r.deletedAt IS NULL
+              AND q.deletedAt IS NULL
+              AND r.userId IN (SELECT u.id FROM UserEntity u WHERE u.deletedAt IS NULL)
+            """)
+    List<ReflectionEntity> findAllByDateAndQuestionCategory(
+            @Param("date") LocalDate date,
+            @Param("category") ZtpiCategory category);
+
+    @Query("""
+            SELECT r
+            FROM ReflectionEntity r
+            WHERE r.date = :date
+              AND r.userId IN :userIds
+              AND r.deletedAt IS NULL
+            """)
+    List<ReflectionEntity> findAllByDateAndUserIdIn(
+            @Param("date") LocalDate date,
+            @Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/dnd5/timoapi/domain/user/domain/entity/UserEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/domain/entity/UserEntity.java
@@ -49,12 +49,15 @@ public class UserEntity extends BaseEntity {
     @Column(nullable = false)
     private Integer streakDays = 0;
 
+    @Column(nullable = false)
+    private Integer totalDays = 0;
+
     public static UserEntity from(User model) {
-        return new UserEntity(model.email(), model.nickname(), model.timezone(), model.provider(), model.role(), model.category(), model.isOnboarded(), model.streakDays());
+        return new UserEntity(model.email(), model.nickname(), model.timezone(), model.provider(), model.role(), model.category(), model.isOnboarded(), model.streakDays(), model.totalDays());
     }
 
     public User toModel() {
-        return new User(getId(), email, nickname, timezone, provider, role, category, isOnboarded, streakDays, getCreatedAt(), getUpdatedAt());
+        return new User(getId(), email, nickname, timezone, provider, role, category, isOnboarded, streakDays, totalDays, getCreatedAt(), getUpdatedAt());
     }
 
     public void update(String nickname) {
@@ -79,5 +82,9 @@ public class UserEntity extends BaseEntity {
 
     public void resetStreakDays() {
         this.streakDays = 0;
+    }
+
+    public void incrementTotalDays() {
+        this.totalDays++;
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/user/domain/model/User.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/domain/model/User.java
@@ -16,10 +16,11 @@ public record User(
         ZtpiCategory category,
         Boolean isOnboarded,
         Integer streakDays,
+        Integer totalDays,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
     public static User create(String email, String nickname, String timezone, OAuthProvider provider) {
-        return new User(null, email, nickname, timezone, provider, UserRole.USER, null,false, 0, null, null);
+        return new User(null, email, nickname, timezone, provider, UserRole.USER, null, false, 0, 0, null, null);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/dnd5/timoapi/global/security/config/SecurityConfig.java
@@ -93,6 +93,9 @@ public class SecurityConfig {
                         // 알림
                         .requestMatchers("/notifications/**").authenticated()
 
+                        // 그룹
+                        .requestMatchers("/groups/**").authenticated()
+
                         // 테스트 (유저)
                         .requestMatchers(HttpMethod.GET, "/tests").authenticated()
                         .requestMatchers(HttpMethod.GET, "/tests/*/questions").authenticated()

--- a/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupServiceTest.java
+++ b/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupServiceTest.java
@@ -1,0 +1,302 @@
+package com.dnd5.timoapi.domain.group.application.service;
+
+import com.dnd5.timoapi.domain.group.domain.entity.GroupEntity;
+import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberEntity;
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupMemberRole;
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberRepository;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupRepository;
+import com.dnd5.timoapi.domain.group.exception.GroupErrorCode;
+import com.dnd5.timoapi.domain.group.presentation.request.GroupCreateRequest;
+import com.dnd5.timoapi.domain.group.presentation.request.GroupUpdateRequest;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupCreateResponse;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupResponse;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupSummaryResponse;
+import com.dnd5.timoapi.global.exception.BusinessException;
+import com.dnd5.timoapi.global.security.context.SecurityUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GroupServiceTest {
+
+    @InjectMocks
+    private GroupService groupService;
+
+    @Mock
+    private GroupRepository groupRepository;
+
+    @Mock
+    private GroupMemberRepository groupMemberRepository;
+
+    @Test
+    void createGroup_성공_코드_자동_생성() {
+        Long userId = 1L;
+        GroupCreateRequest request = new GroupCreateRequest("팀A", GroupType.FRIEND, null);
+
+        GroupEntity savedGroup = mock(GroupEntity.class);
+        when(savedGroup.getId()).thenReturn(10L);
+        when(savedGroup.toModel()).thenReturn(
+                new com.dnd5.timoapi.domain.group.domain.model.Group(10L, "ABCD1234", "팀A", GroupType.FRIEND, null, null, null)
+        );
+
+        when(groupRepository.existsByCodeAndDeletedAtIsNull(anyString())).thenReturn(false);
+        when(groupRepository.save(any())).thenReturn(savedGroup);
+        when(groupMemberRepository.save(any())).thenReturn(mock(GroupMemberEntity.class));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            GroupCreateResponse response = groupService.createGroup(request);
+
+            assertThat(response.id()).isEqualTo(10L);
+            assertThat(response.code()).isEqualTo("ABCD1234");
+        }
+
+        verify(groupRepository).save(any());
+        verify(groupMemberRepository).save(any());
+    }
+
+    @Test
+    void getMyGroups_내_그룹만_반환() {
+        Long userId = 1L;
+
+        GroupMemberEntity membership = mock(GroupMemberEntity.class);
+        when(membership.getGroupId()).thenReturn(10L);
+        when(membership.getRole()).thenReturn(GroupMemberRole.OWNER);
+
+        GroupEntity groupEntity = mock(GroupEntity.class);
+        when(groupEntity.getId()).thenReturn(10L);
+        when(groupEntity.toModel()).thenReturn(
+                new com.dnd5.timoapi.domain.group.domain.model.Group(10L, "CODE1234", "팀A", GroupType.FRIEND, null, null, null)
+        );
+
+        when(groupMemberRepository.findAllByUserIdAndDeletedAtIsNull(userId)).thenReturn(List.of(membership));
+        when(groupRepository.findByIdAndDeletedAtIsNull(10L)).thenReturn(Optional.of(groupEntity));
+        when(groupMemberRepository.countByGroupIdAndDeletedAtIsNull(10L)).thenReturn(3L);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            List<GroupSummaryResponse> result = groupService.getMyGroups();
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).memberCount()).isEqualTo(3);
+            assertThat(result.get(0).myRole()).isEqualTo(GroupMemberRole.OWNER);
+        }
+    }
+
+    @Test
+    void getGroup_멤버가_code_없이_조회_성공() {
+        Long userId = 1L;
+        Long groupId = 10L;
+
+        GroupEntity groupEntity = mock(GroupEntity.class);
+        when(groupEntity.toModel()).thenReturn(
+                new com.dnd5.timoapi.domain.group.domain.model.Group(groupId, "ABCD1234", "팀A", GroupType.FRIEND, null, null, null)
+        );
+
+        GroupMemberEntity member = mock(GroupMemberEntity.class);
+        when(member.getRole()).thenReturn(GroupMemberRole.MEMBER);
+
+        when(groupRepository.findByIdAndDeletedAtIsNull(groupId)).thenReturn(Optional.of(groupEntity));
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)).thenReturn(true);
+        when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)).thenReturn(Optional.of(member));
+        when(groupMemberRepository.countByGroupIdAndDeletedAtIsNull(groupId)).thenReturn(5L);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            GroupResponse response = groupService.getGroup(groupId, null);
+
+            assertThat(response.isMember()).isTrue();
+            assertThat(response.myRole()).isEqualTo(GroupMemberRole.MEMBER);
+            assertThat(response.memberCount()).isEqualTo(5);
+        }
+    }
+
+    @Test
+    void getGroup_비멤버가_올바른_code로_조회_성공() {
+        Long userId = 1L;
+        Long groupId = 10L;
+        String code = "ABCD1234";
+
+        GroupEntity groupEntity = mock(GroupEntity.class);
+        when(groupEntity.getCode()).thenReturn(code);
+        when(groupEntity.toModel()).thenReturn(
+                new com.dnd5.timoapi.domain.group.domain.model.Group(groupId, code, "팀A", GroupType.FRIEND, null, null, null)
+        );
+
+        when(groupRepository.findByIdAndDeletedAtIsNull(groupId)).thenReturn(Optional.of(groupEntity));
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)).thenReturn(false);
+        when(groupMemberRepository.countByGroupIdAndDeletedAtIsNull(groupId)).thenReturn(2L);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            GroupResponse response = groupService.getGroup(groupId, code);
+
+            assertThat(response.isMember()).isFalse();
+            assertThat(response.myRole()).isNull();
+        }
+    }
+
+    @Test
+    void getGroup_잘못된_code면_403() {
+        Long userId = 1L;
+        Long groupId = 10L;
+
+        GroupEntity groupEntity = mock(GroupEntity.class);
+        when(groupEntity.getCode()).thenReturn("CORRECT1");
+        when(groupRepository.findByIdAndDeletedAtIsNull(groupId)).thenReturn(Optional.of(groupEntity));
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)).thenReturn(false);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            assertThatThrownBy(() -> groupService.getGroup(groupId, "WRONGCOD"))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_ACCESS_DENIED));
+        }
+    }
+
+    @Test
+    void getGroup_비멤버가_code_없이_조회시_403() {
+        Long userId = 1L;
+        Long groupId = 10L;
+
+        GroupEntity groupEntity = mock(GroupEntity.class);
+        when(groupRepository.findByIdAndDeletedAtIsNull(groupId)).thenReturn(Optional.of(groupEntity));
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)).thenReturn(false);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            assertThatThrownBy(() -> groupService.getGroup(groupId, null))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_ACCESS_DENIED));
+        }
+    }
+
+    @Test
+    void updateGroup_OWNER가_아니면_403() {
+        Long userId = 1L;
+        Long groupId = 10L;
+
+        GroupMemberEntity member = mock(GroupMemberEntity.class);
+        when(member.getRole()).thenReturn(GroupMemberRole.MEMBER);
+        when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)).thenReturn(Optional.of(member));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            assertThatThrownBy(() -> groupService.updateGroup(groupId, new GroupUpdateRequest("새이름", null)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_FORBIDDEN));
+        }
+    }
+
+    @Test
+    void joinGroup_이미_참여중이면_409() {
+        Long userId = 1L;
+        Long groupId = 10L;
+
+        GroupEntity groupEntity = mock(GroupEntity.class);
+        when(groupRepository.findByIdAndDeletedAtIsNull(groupId)).thenReturn(Optional.of(groupEntity));
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)).thenReturn(true);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            assertThatThrownBy(() -> groupService.joinGroup(groupId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_ALREADY_JOINED));
+        }
+    }
+
+    @Test
+    void joinGroup_탈퇴후_재가입시_restore() {
+        Long userId = 1L;
+        Long groupId = 10L;
+
+        GroupEntity groupEntity = mock(GroupEntity.class);
+        GroupMemberEntity softDeletedMember = mock(GroupMemberEntity.class);
+
+        when(groupRepository.findByIdAndDeletedAtIsNull(groupId)).thenReturn(Optional.of(groupEntity));
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)).thenReturn(false);
+        when(groupMemberRepository.findByGroupIdAndUserId(groupId, userId)).thenReturn(Optional.of(softDeletedMember));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            groupService.joinGroup(groupId);
+
+            verify(softDeletedMember).restore();
+            verify(groupMemberRepository, never()).save(any());
+        }
+    }
+
+    @Test
+    void leaveGroup_OWNER_혼자면_그룹_소프트딜리트() {
+        Long userId = 1L;
+        Long groupId = 10L;
+
+        GroupMemberEntity ownerMember = mock(GroupMemberEntity.class);
+        when(ownerMember.getRole()).thenReturn(GroupMemberRole.OWNER);
+        when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)).thenReturn(Optional.of(ownerMember));
+        when(groupMemberRepository.countByGroupIdAndDeletedAtIsNull(groupId)).thenReturn(1L);
+
+        GroupEntity groupEntity = mock(GroupEntity.class);
+        when(groupRepository.findByIdAndDeletedAtIsNull(groupId)).thenReturn(Optional.of(groupEntity));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            groupService.leaveGroup(groupId);
+
+            verify(groupEntity).softDelete();
+            verify(ownerMember).softDelete();
+        }
+    }
+
+    @Test
+    void leaveGroup_OWNER_탈퇴시_다음_MEMBER에게_소유권_이전() {
+        Long userId = 1L;
+        Long groupId = 10L;
+
+        GroupMemberEntity ownerMember = mock(GroupMemberEntity.class);
+        when(ownerMember.getRole()).thenReturn(GroupMemberRole.OWNER);
+        when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)).thenReturn(Optional.of(ownerMember));
+        when(groupMemberRepository.countByGroupIdAndDeletedAtIsNull(groupId)).thenReturn(3L);
+
+        GroupMemberEntity nextMember = mock(GroupMemberEntity.class);
+        when(groupMemberRepository.findTopByGroupIdAndRoleAndDeletedAtIsNullOrderByCreatedAtAsc(groupId, GroupMemberRole.MEMBER))
+                .thenReturn(Optional.of(nextMember));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            groupService.leaveGroup(groupId);
+
+            verify(nextMember).promoteToOwner();
+            verify(ownerMember).softDelete();
+        }
+    }
+}

--- a/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupServiceTest.java
+++ b/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupServiceTest.java
@@ -11,8 +11,8 @@ import com.dnd5.timoapi.domain.group.exception.GroupErrorCode;
 import com.dnd5.timoapi.domain.group.presentation.request.GroupCreateRequest;
 import com.dnd5.timoapi.domain.group.presentation.request.GroupUpdateRequest;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupCreateResponse;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupDetailResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupResponse;
-import com.dnd5.timoapi.domain.group.presentation.response.GroupSummaryResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupTodayReflectionItem;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionQuestionEntity;
@@ -138,7 +138,7 @@ class GroupServiceTest {
         try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
             mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-            List<GroupSummaryResponse> result = groupService.getMyGroups();
+            List<GroupResponse> result = groupService.getMyGroups();
 
             assertThat(result).hasSize(1);
             assertThat(result.get(0).memberCount()).isEqualTo(3);
@@ -167,7 +167,7 @@ class GroupServiceTest {
         try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
             mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-            GroupResponse response = groupService.getGroup(groupId, null);
+            GroupDetailResponse response = groupService.getGroup(groupId, null);
 
             assertThat(response.isMember()).isTrue();
             assertThat(response.myRole()).isEqualTo(GroupMemberRole.MEMBER);
@@ -194,7 +194,7 @@ class GroupServiceTest {
         try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
             mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-            GroupResponse response = groupService.getGroup(groupId, code);
+            GroupDetailResponse response = groupService.getGroup(groupId, code);
 
             assertThat(response.isMember()).isFalse();
             assertThat(response.myRole()).isNull();

--- a/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupServiceTest.java
+++ b/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupServiceTest.java
@@ -4,6 +4,7 @@ import com.dnd5.timoapi.domain.group.domain.entity.GroupEntity;
 import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberEntity;
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupMemberRole;
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupReflectionSort;
 import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberRepository;
 import com.dnd5.timoapi.domain.group.domain.repository.GroupRepository;
 import com.dnd5.timoapi.domain.group.exception.GroupErrorCode;
@@ -12,6 +13,14 @@ import com.dnd5.timoapi.domain.group.presentation.request.GroupUpdateRequest;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupCreateResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupSummaryResponse;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupTodayReflectionItem;
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionQuestionEntity;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionQuestionRepository;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
+import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
 import com.dnd5.timoapi.global.exception.BusinessException;
 import com.dnd5.timoapi.global.security.context.SecurityUtil;
 import org.junit.jupiter.api.Test;
@@ -22,6 +31,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -42,15 +52,24 @@ class GroupServiceTest {
     @Mock
     private GroupMemberRepository groupMemberRepository;
 
+    @Mock
+    private ReflectionRepository reflectionRepository;
+
+    @Mock
+    private ReflectionQuestionRepository reflectionQuestionRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
     @Test
-    void createGroup_성공_코드_자동_생성() {
+    void createGroup_FRIEND_성공_코드_자동_생성() {
         Long userId = 1L;
-        GroupCreateRequest request = new GroupCreateRequest("팀A", GroupType.FRIEND, null);
+        GroupCreateRequest request = new GroupCreateRequest("팀A", GroupType.FRIEND, null, null);
 
         GroupEntity savedGroup = mock(GroupEntity.class);
         when(savedGroup.getId()).thenReturn(10L);
         when(savedGroup.toModel()).thenReturn(
-                new com.dnd5.timoapi.domain.group.domain.model.Group(10L, "ABCD1234", "팀A", GroupType.FRIEND, null, null, null)
+                new com.dnd5.timoapi.domain.group.domain.model.Group(10L, "ABCD1234", "팀A", GroupType.FRIEND, null, null, null, null)
         );
 
         when(groupRepository.existsByCodeAndDeletedAtIsNull(anyString())).thenReturn(false);
@@ -71,6 +90,34 @@ class GroupServiceTest {
     }
 
     @Test
+    void createGroup_CHARACTER_category_없으면_400() {
+        GroupCreateRequest request = new GroupCreateRequest("캐릭터그룹", GroupType.CHARACTER, null, null);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(1L);
+
+            assertThatThrownBy(() -> groupService.createGroup(request))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_INVALID_CATEGORY));
+        }
+    }
+
+    @Test
+    void createGroup_FRIEND_category_있으면_400() {
+        GroupCreateRequest request = new GroupCreateRequest("팀A", GroupType.FRIEND, null, ZtpiCategory.FUTURE);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(1L);
+
+            assertThatThrownBy(() -> groupService.createGroup(request))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_INVALID_CATEGORY));
+        }
+    }
+
+    @Test
     void getMyGroups_내_그룹만_반환() {
         Long userId = 1L;
 
@@ -81,7 +128,7 @@ class GroupServiceTest {
         GroupEntity groupEntity = mock(GroupEntity.class);
         when(groupEntity.getId()).thenReturn(10L);
         when(groupEntity.toModel()).thenReturn(
-                new com.dnd5.timoapi.domain.group.domain.model.Group(10L, "CODE1234", "팀A", GroupType.FRIEND, null, null, null)
+                new com.dnd5.timoapi.domain.group.domain.model.Group(10L, "CODE1234", "팀A", GroupType.FRIEND, null, null, null, null)
         );
 
         when(groupMemberRepository.findAllByUserIdAndDeletedAtIsNull(userId)).thenReturn(List.of(membership));
@@ -106,7 +153,7 @@ class GroupServiceTest {
 
         GroupEntity groupEntity = mock(GroupEntity.class);
         when(groupEntity.toModel()).thenReturn(
-                new com.dnd5.timoapi.domain.group.domain.model.Group(groupId, "ABCD1234", "팀A", GroupType.FRIEND, null, null, null)
+                new com.dnd5.timoapi.domain.group.domain.model.Group(groupId, "ABCD1234", "팀A", GroupType.FRIEND, null, null, null, null)
         );
 
         GroupMemberEntity member = mock(GroupMemberEntity.class);
@@ -137,7 +184,7 @@ class GroupServiceTest {
         GroupEntity groupEntity = mock(GroupEntity.class);
         when(groupEntity.getCode()).thenReturn(code);
         when(groupEntity.toModel()).thenReturn(
-                new com.dnd5.timoapi.domain.group.domain.model.Group(groupId, code, "팀A", GroupType.FRIEND, null, null, null)
+                new com.dnd5.timoapi.domain.group.domain.model.Group(groupId, code, "팀A", GroupType.FRIEND, null, null, null, null)
         );
 
         when(groupRepository.findByIdAndDeletedAtIsNull(groupId)).thenReturn(Optional.of(groupEntity));
@@ -297,6 +344,75 @@ class GroupServiceTest {
 
             verify(nextMember).promoteToOwner();
             verify(ownerMember).softDelete();
+        }
+    }
+
+    @Test
+    void getTodayReflections_FRIEND_비멤버_403() {
+        Long userId = 1L;
+        Long groupId = 10L;
+
+        GroupEntity groupEntity = mock(GroupEntity.class);
+        when(groupEntity.getType()).thenReturn(GroupType.FRIEND);
+        when(groupRepository.findByIdAndDeletedAtIsNull(groupId)).thenReturn(Optional.of(groupEntity));
+
+        GroupMemberEntity member = mock(GroupMemberEntity.class);
+        when(member.getUserId()).thenReturn(2L);
+        when(groupMemberRepository.findAllByGroupIdAndDeletedAtIsNull(groupId)).thenReturn(List.of(member));
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)).thenReturn(false);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            assertThatThrownBy(() -> groupService.getTodayReflections(groupId, GroupReflectionSort.LATEST))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_ACCESS_DENIED));
+        }
+    }
+
+    @Test
+    void getTodayReflections_CHARACTER_전체_유저_회고_반환() {
+        Long userId = 1L;
+        Long groupId = 10L;
+
+        GroupEntity groupEntity = mock(GroupEntity.class);
+        when(groupEntity.getType()).thenReturn(GroupType.CHARACTER);
+        when(groupEntity.getCategory()).thenReturn(ZtpiCategory.FUTURE);
+        when(groupRepository.findByIdAndDeletedAtIsNull(groupId)).thenReturn(Optional.of(groupEntity));
+
+        ReflectionEntity reflection = mock(ReflectionEntity.class);
+        when(reflection.getUserId()).thenReturn(2L);
+        when(reflection.getQuestionId()).thenReturn(100L);
+        when(reflection.getAnswerText()).thenReturn("회고 내용");
+
+        ReflectionQuestionEntity question = mock(ReflectionQuestionEntity.class);
+        when(question.getId()).thenReturn(100L);
+        when(question.getContent()).thenReturn("오늘의 질문");
+        when(question.getCategory()).thenReturn(ZtpiCategory.FUTURE);
+
+        UserEntity user = mock(UserEntity.class);
+        when(user.getId()).thenReturn(2L);
+        when(user.getNickname()).thenReturn("홍길동");
+        when(user.getStreakDays()).thenReturn(5);
+        when(user.getTotalDays()).thenReturn(30);
+
+        when(reflectionRepository.findAllByDateAndQuestionCategory(any(LocalDate.class), eq(ZtpiCategory.FUTURE)))
+                .thenReturn(List.of(reflection));
+        when(reflectionQuestionRepository.findAllById(anyList())).thenReturn(List.of(question));
+        when(userRepository.findAllById(anyList())).thenReturn(List.of(user));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            List<GroupTodayReflectionItem> result = groupService.getTodayReflections(groupId, GroupReflectionSort.LATEST);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).nickname()).isEqualTo("홍길동");
+            assertThat(result.get(0).questionCategory()).isEqualTo(ZtpiCategory.FUTURE);
+            assertThat(result.get(0).answerText()).isEqualTo("회고 내용");
+            assertThat(result.get(0).streakDays()).isEqualTo(5);
+            assertThat(result.get(0).totalDays()).isEqualTo(30);
         }
     }
 }


### PR DESCRIPTION
## Summary

- 그룹 CRUD + 멤버 참여/탈퇴 API 7개 구현
- CHARACTER / FRIEND 두 가지 그룹 타입 지원
- 그룹 내 오늘의 회고 피드 조회 API (정렬 옵션 포함)
- 누적 회고 일수(`total_days`) 추적

## 주요 기능

### 그룹 관리
| 엔드포인트 | 설명 |
|---|---|
| `POST /groups` | 그룹 생성 (초대 코드 자동 발급, 생성자 OWNER 등록) |
| `GET /groups` | 내가 속한 그룹 목록 |
| `GET /groups/{groupId}?code={code}` | 상세 조회 (초대 링크 공유 시 비멤버 접근 가능) |
| `PATCH /groups/{groupId}` | 수정 (OWNER만) |
| `DELETE /groups/{groupId}` | 삭제 (OWNER만) |
| `POST /groups/{groupId}/members` | 참여 |
| `DELETE /groups/{groupId}/members` | 탈퇴 |

### 오늘의 회고 피드
| 엔드포인트 | 설명 |
|---|---|
| `GET /groups/{groupId}/reflections/today?sort=LATEST` | 오늘의 회고 피드 |

**정렬 옵션**: `LATEST`(기본) / `STREAK`(연속률) / `TOTAL`(누적 회고)

### 그룹 타입별 동작
- **FRIEND**: 그룹 멤버 중 오늘 회고한 사람만 표시, 비멤버 접근 차단
- **CHARACTER**: 서비스 전체 유저 중 해당 ZTPI 캐릭터 질문으로 오늘 회고한 모든 사람 표시, 비멤버도 접근 가능

### Edge Case 처리
- OWNER 혼자 탈퇴 → 그룹 soft delete
- OWNER 탈퇴 (멤버 있음) → 가장 먼저 가입한 MEMBER에게 소유권 이전
- 탈퇴 후 재가입 → 기존 레코드 restore (중복 row 방지)

## Schema 변경
- `groups` 테이블: `category` VARCHAR 컬럼 추가 (CHARACTER 타입 전용)
- `group_members` 테이블: `role` VARCHAR 컬럼 (OWNER/MEMBER)
- `users` 테이블: `total_days` INTEGER 컬럼 추가

## Test plan
- [ ] 그룹 CRUD 동작 확인
- [ ] 초대 링크(groupId + code)로 비멤버 상세 조회
- [ ] CHARACTER/FRIEND 그룹 생성 시 category 검증 (400 응답)
- [ ] FRIEND 피드: 비멤버 접근 403
- [ ] CHARACTER 피드: 비멤버 접근 허용, 전체 유저 회고 표시
- [ ] sort=STREAK, TOTAL 정렬 순서 확인
- [ ] 회고 생성 시 total_days 증가 확인
- [ ] 단위 테스트 15개 통과 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can create groups with auto-generated unique codes and specify group type and optional category
  * Join and leave group functionality with automatic ownership transfers when necessary
  * View personal group memberships and detailed group information
  * Retrieve and sort group reflections by latest, streak count, or total days
  * Update group name and image (owner-only)
  * Delete groups with automatic membership cleanup
  * Track total reflection days contributed by users

* **Tests**
  * Added comprehensive test suite for group operations

* **Security**
  * Group endpoints now require user authentication

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnd-side-project/dnd-14th-5-backend/pull/98)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->