### PR TITLE
feat/add-attribute-get-reflection-feedback

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackService.java
@@ -45,6 +45,11 @@ public class ReflectionFeedbackService {
                                 0,
                                 null,
                                 FeedbackStatus.PROCESSING,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
                                 null
                         )
                 )));

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/support/ReflectionFeedbackAsyncProcessor.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/support/ReflectionFeedbackAsyncProcessor.java
@@ -6,10 +6,17 @@ import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionQuestionEntity
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionFeedbackRepository;
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionQuestionRepository;
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
+import com.dnd5.timoapi.domain.reflection.domain.model.enums.FeedbackStatus;
 import com.dnd5.timoapi.domain.reflection.exception.ReflectionErrorCode;
 import com.dnd5.timoapi.domain.reflection.infrastructure.ai.FeedbackGenerator;
 import com.dnd5.timoapi.domain.reflection.infrastructure.ai.FeedbackResult;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+import com.dnd5.timoapi.domain.user.domain.entity.UserTestResultEntity;
+import com.dnd5.timoapi.domain.user.domain.repository.UserTestResultRepository;
+import com.dnd5.timoapi.domain.user.exception.UserTestRecordErrorCode;
 import com.dnd5.timoapi.global.exception.BusinessException;
+import java.time.LocalDateTime;
+import java.util.List;
 import com.dnd5.timoapi.global.analytics.event.FeedbackReceivedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +37,7 @@ public class ReflectionFeedbackAsyncProcessor {
     private final ReflectionRepository reflectionRepository;
     private final ReflectionFeedbackRepository reflectionFeedbackRepository;
     private final ReflectionQuestionRepository reflectionQuestionRepository;
+    private final UserTestResultRepository userTestResultRepository;
     private final FeedbackGenerator feedbackGenerator;
 
     @Async("feedbackTaskExecutor")
@@ -54,9 +62,39 @@ public class ReflectionFeedbackAsyncProcessor {
                     reflectionEntity.getAnswerText()
             );
             validateScore(feedbackResult.score());
-            feedbackEntity.complete(feedbackResult.score(), feedbackResult.content());
+
+            ZtpiCategory category = questionEntity.getCategory();
 
             Long userId = reflectionEntity.getUserId();
+            UserTestResultEntity latestTestResult = userTestResultRepository
+                    .findFirstByUserTestRecord_User_IdAndCategoryAndDeletedAtIsNullOrderByCreatedAtDesc(userId, category)
+                    .orElseThrow(() -> new BusinessException(UserTestRecordErrorCode.USER_TEST_RESULT_NOT_FOUND));
+
+            double testScore = latestTestResult.getScore();
+            LocalDateTime latestTestDate = latestTestResult.getCreatedAt();
+
+            List<Integer> previousReflectionFeedbackScores = reflectionFeedbackRepository
+                    .findScoresByUserAndCategoryAfter(userId, category, FeedbackStatus.COMPLETED, latestTestDate, reflectionId);
+
+            List<Integer> nonZeroPreviousScores = previousReflectionFeedbackScores.stream()
+                    .filter(s -> s != 0)
+                    .toList();
+
+            double scoreSum = testScore + nonZeroPreviousScores.stream().mapToInt(Integer::intValue).sum();
+            int count = 1 + nonZeroPreviousScores.size();
+
+            double beforeScore = scoreSum / count;
+
+            int currentScore = feedbackResult.score();
+            double afterScore = currentScore == 0
+                    ? beforeScore
+                    : (scoreSum + currentScore) / (count + 1);
+
+            boolean isIncreased = beforeScore < afterScore;
+            double changedScore = Math.abs(afterScore - beforeScore);
+
+            feedbackEntity.complete(feedbackResult.score(), feedbackResult.content(), category, isIncreased, changedScore, beforeScore, afterScore);
+
             eventPublisher.publishEvent(new FeedbackReceivedEvent(userId, reflectionId, feedbackResult.score()));
         } catch (Exception e) {
             log.error("Feedback generation failed for reflectionId={}", reflectionId, e);

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/domain/entity/ReflectionFeedbackEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/domain/entity/ReflectionFeedbackEntity.java
@@ -2,6 +2,7 @@ package com.dnd5.timoapi.domain.reflection.domain.entity;
 
 import com.dnd5.timoapi.domain.reflection.domain.model.ReflectionFeedback;
 import com.dnd5.timoapi.domain.reflection.domain.model.enums.FeedbackStatus;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import com.dnd5.timoapi.global.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -32,12 +33,28 @@ public class ReflectionFeedbackEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private FeedbackStatus status;
 
+    @Enumerated(EnumType.STRING)
+    private ZtpiCategory category;
+
+    private Boolean isIncreased;
+
+    private Double changedScore;
+
+    private Double beforeScore;
+
+    private Double afterScore;
+
     public static ReflectionFeedbackEntity from(ReflectionFeedback model) {
         return new ReflectionFeedbackEntity(
                 model.reflectionId(),
                 model.score(),
                 model.content(),
-                model.status()
+                model.status(),
+                model.category(),
+                model.isIncreased(),
+                model.changedScore(),
+                model.beforeScore(),
+                model.afterScore()
         );
     }
 
@@ -48,14 +65,24 @@ public class ReflectionFeedbackEntity extends BaseEntity {
                 getScore(),
                 getContent(),
                 getStatus(),
+                getCategory(),
+                getIsIncreased(),
+                getChangedScore(),
+                getBeforeScore(),
+                getAfterScore(),
                 getCreatedAt()
         );
     }
 
-    public void complete(int score, String content) {
+    public void complete(int score, String content, ZtpiCategory category, Boolean isIncreased, Double changedScore, Double beforeScore, Double afterScore) {
         this.score = score;
         this.content = content;
         this.status = FeedbackStatus.COMPLETED;
+        this.category = category;
+        this.isIncreased = isIncreased;
+        this.changedScore = changedScore;
+        this.beforeScore = beforeScore;
+        this.afterScore = afterScore;
     }
 
     public void fail() {
@@ -66,5 +93,10 @@ public class ReflectionFeedbackEntity extends BaseEntity {
         this.score = 0;
         this.content = null;
         this.status = FeedbackStatus.PROCESSING;
+        this.category = null;
+        this.isIncreased = null;
+        this.changedScore = null;
+        this.beforeScore = null;
+        this.afterScore = null;
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/domain/model/ReflectionFeedback.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/domain/model/ReflectionFeedback.java
@@ -1,6 +1,7 @@
 package com.dnd5.timoapi.domain.reflection.domain.model;
 
 import com.dnd5.timoapi.domain.reflection.domain.model.enums.FeedbackStatus;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import java.time.LocalDateTime;
 
 public record ReflectionFeedback(
@@ -9,6 +10,11 @@ public record ReflectionFeedback(
         int score,
         String content,
         FeedbackStatus status,
+        ZtpiCategory category,
+        Boolean isIncreased,
+        Double changedScore,
+        Double beforeScore,
+        Double afterScore,
         LocalDateTime createdAt
 ) {
 

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/domain/repository/ReflectionFeedbackRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/domain/repository/ReflectionFeedbackRepository.java
@@ -1,8 +1,14 @@
 package com.dnd5.timoapi.domain.reflection.domain.repository;
 
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionFeedbackEntity;
+import com.dnd5.timoapi.domain.reflection.domain.model.enums.FeedbackStatus;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReflectionFeedbackRepository extends
         JpaRepository<ReflectionFeedbackEntity, Long> {
@@ -10,4 +16,21 @@ public interface ReflectionFeedbackRepository extends
     boolean existsByReflectionId(Long reflectionId);
 
     Optional<ReflectionFeedbackEntity> findByReflectionId(Long reflectionId);
+
+    @Query("""
+            SELECT rf.score FROM ReflectionFeedbackEntity rf
+            WHERE rf.reflectionId IN (SELECT r.id FROM ReflectionEntity r WHERE r.userId = :userId)
+            AND rf.category = :category
+            AND rf.status = :status
+            AND rf.createdAt > :afterDate
+            AND rf.reflectionId != :excludeReflectionId
+            AND rf.deletedAt IS NULL
+            """)
+    List<Integer> findScoresByUserAndCategoryAfter(
+            @Param("userId") Long userId,
+            @Param("category") ZtpiCategory category,
+            @Param("status") FeedbackStatus status,
+            @Param("afterDate") LocalDateTime afterDate,
+            @Param("excludeReflectionId") Long excludeReflectionId
+    );
 }

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/presentation/response/ReflectionFeedbackDetailResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/presentation/response/ReflectionFeedbackDetailResponse.java
@@ -2,14 +2,21 @@ package com.dnd5.timoapi.domain.reflection.presentation.response;
 
 import com.dnd5.timoapi.domain.reflection.domain.model.ReflectionFeedback;
 import com.dnd5.timoapi.domain.reflection.domain.model.enums.FeedbackStatus;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+
 import java.time.LocalDateTime;
 
 public record ReflectionFeedbackDetailResponse(
         Long id,
         Long reflectionId,
+        ZtpiCategory category,
         int score,
         String content,
         FeedbackStatus status,
+        Boolean isIncreased,
+        Double changedScore,
+        Double beforeScore,
+        Double afterScore,
         LocalDateTime createdAt,
         String failureReason
 ) {
@@ -22,9 +29,14 @@ public record ReflectionFeedbackDetailResponse(
         return new ReflectionFeedbackDetailResponse(
                 model.id(),
                 model.reflectionId(),
+                model.category(),
                 model.score(),
                 model.content(),
                 model.status(),
+                model.isIncreased(),
+                model.changedScore(),
+                model.beforeScore(),
+                model.afterScore(),
                 model.createdAt(),
                 failureReason
         );

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/presentation/response/ReflectionFeedbackResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/presentation/response/ReflectionFeedbackResponse.java
@@ -2,6 +2,7 @@ package com.dnd5.timoapi.domain.reflection.presentation.response;
 
 import com.dnd5.timoapi.domain.reflection.domain.model.ReflectionFeedback;
 import com.dnd5.timoapi.domain.reflection.domain.model.enums.FeedbackStatus;
+
 import java.time.LocalDateTime;
 
 public record ReflectionFeedbackResponse(

--- a/src/main/java/com/dnd5/timoapi/domain/user/domain/repository/UserTestResultRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/domain/repository/UserTestResultRepository.java
@@ -1,13 +1,17 @@
 package com.dnd5.timoapi.domain.user.domain.repository;
 
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import com.dnd5.timoapi.domain.user.domain.entity.UserTestResultEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserTestResultRepository extends JpaRepository<UserTestResultEntity, Long> {
 
     List<UserTestResultEntity> findByUserTestRecordId(Long userTestRecordId);
     List<UserTestResultEntity> findAllByUserTestRecordId(Long testRecordId);
     List<UserTestResultEntity> findAllByUserTestRecordIdAndDeletedAtIsNull(Long testRecordId);
+
+    Optional<UserTestResultEntity> findFirstByUserTestRecord_User_IdAndCategoryAndDeletedAtIsNullOrderByCreatedAtDesc(Long userId, ZtpiCategory category);
 }

--- a/src/test/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackServiceTest.java
+++ b/src/test/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionFeedbackServiceTest.java
@@ -73,7 +73,7 @@ class ReflectionFeedbackServiceTest {
         when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflectionEntity));
         when(reflectionFeedbackRepository.findByReflectionId(reflectionId)).thenReturn(Optional.empty());
 
-        ReflectionFeedbackEntity processingFeedback = new ReflectionFeedbackEntity(reflectionId, 0, null, FeedbackStatus.PROCESSING);
+        ReflectionFeedbackEntity processingFeedback = new ReflectionFeedbackEntity(reflectionId, 0, null, FeedbackStatus.PROCESSING, null, null, null, null, null);
         when(reflectionFeedbackRepository.save(any())).thenReturn(processingFeedback);
 
         try (MockedStatic<SecurityUtil> securityMocked = Mockito.mockStatic(SecurityUtil.class);
@@ -96,7 +96,7 @@ class ReflectionFeedbackServiceTest {
         when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflectionEntity));
 
         ReflectionFeedbackEntity failedFeedback = spy(
-                new ReflectionFeedbackEntity(reflectionId, 0, null, FeedbackStatus.FAILED)
+                new ReflectionFeedbackEntity(reflectionId, 0, null, FeedbackStatus.FAILED, null, null, null, null, null)
         );
         when(reflectionFeedbackRepository.findByReflectionId(reflectionId))
                 .thenReturn(Optional.of(failedFeedback));
@@ -123,7 +123,7 @@ class ReflectionFeedbackServiceTest {
         ReflectionEntity reflectionEntity = new ReflectionEntity(1L, 3L, LocalDate.now(), "회고 내용");
         when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflectionEntity));
 
-        ReflectionFeedbackEntity processingFeedback = new ReflectionFeedbackEntity(reflectionId, 0, null, FeedbackStatus.PROCESSING);
+        ReflectionFeedbackEntity processingFeedback = new ReflectionFeedbackEntity(reflectionId, 0, null, FeedbackStatus.PROCESSING, null, null, null, null, null);
         when(reflectionFeedbackRepository.findByReflectionId(reflectionId))
                 .thenReturn(Optional.of(processingFeedback));
 
@@ -146,7 +146,7 @@ class ReflectionFeedbackServiceTest {
         ReflectionEntity reflectionEntity = new ReflectionEntity(1L, 3L, LocalDate.now(), "회고 내용");
         when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflectionEntity));
 
-        ReflectionFeedbackEntity completedFeedback = new ReflectionFeedbackEntity(reflectionId, 80, "피드백", FeedbackStatus.COMPLETED);
+        ReflectionFeedbackEntity completedFeedback = new ReflectionFeedbackEntity(reflectionId, 80, "피드백", FeedbackStatus.COMPLETED, null, null, null, null, null);
         when(reflectionFeedbackRepository.findByReflectionId(reflectionId))
                 .thenReturn(Optional.of(completedFeedback));
 


### PR DESCRIPTION
## What is this PR? :mag:
- 사용자가 회고로부터 얻는 AI 피드백 점수를 반영하도록 로직 수정
- 이후 카테고리 점수 변화 그래프로 확장 가능

## Changes :memo:
- reflection_feedbacks 테이블에 5개의 컬럼을 추가 (category, before_score, after_score, is_increased, changed_score)
- 피드백 완료 시 최신 ZTPI 테스트 점수를 기준으로 카테고리별 before/after 점수 계산
- 점수 0인 피드백은 평균 계산 카운트에서 제외
- ZTPI 재테스트 시 새 테스트 이후 회고만 반영되도록 기준점 초기화

---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reflection feedback now includes ZTPI category, an increase/decrease indicator, and detailed before/after score values visible in feedback details.

* **Enhancements**
  * Score baselines are computed using recent test results and prior feedback, improving the accuracy of reported score changes and insights.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnd-side-project/dnd-14th-5-backend/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->