### PR TITLE
fix/groups

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupService.java
@@ -155,26 +155,15 @@ public class GroupService {
         GroupEntity groupEntity = getGroupEntity(groupId);
         LocalDate today = LocalDate.now();
 
-        List<ReflectionEntity> reflections;
-
         if (groupEntity.getType() == GroupType.CHARACTER) {
-            reflections = reflectionRepository.findAllByDateAndQuestionCategory(today, groupEntity.getCategory());
-        } else {
-            List<Long> memberUserIds = groupMemberRepository.findAllByGroupIdAndDeletedAtIsNull(groupId)
-                    .stream()
-                    .map(GroupMemberEntity::getUserId)
-                    .toList();
-
-            if (!groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)) {
-                throw new BusinessException(GroupErrorCode.GROUP_ACCESS_DENIED);
-            }
-
-            if (memberUserIds.isEmpty()) {
-                return List.of();
-            }
-            reflections = reflectionRepository.findAllByDateAndUserIdIn(today, memberUserIds);
+            return getTodayReflectionsForCharacterGroup(groupEntity, today, sort);
         }
+        return getTodayReflectionsForFriendGroup(groupId, userId, today, sort);
+    }
 
+    private List<GroupTodayReflectionItem> getTodayReflectionsForCharacterGroup(
+            GroupEntity groupEntity, LocalDate today, GroupReflectionSort sort) {
+        List<ReflectionEntity> reflections = reflectionRepository.findAllByDateAndQuestionCategory(today, groupEntity.getCategory());
         if (reflections.isEmpty()) {
             return List.of();
         }
@@ -183,9 +172,9 @@ public class GroupService {
         List<Long> userIds = reflections.stream().map(ReflectionEntity::getUserId).distinct().toList();
 
         Map<Long, ReflectionQuestionEntity> questionMap = reflectionQuestionRepository.findAllById(questionIds)
-                .stream().collect(Collectors.toMap(q -> q.getId(), q -> q));
+                .stream().collect(Collectors.toMap(ReflectionQuestionEntity::getId, q -> q));
         Map<Long, UserEntity> userMap = userRepository.findAllById(userIds)
-                .stream().collect(Collectors.toMap(u -> u.getId(), u -> u));
+                .stream().collect(Collectors.toMap(UserEntity::getId, u -> u));
 
         Comparator<ReflectionEntity> comparator = switch (sort) {
             case STREAK -> Comparator.comparingInt((ReflectionEntity r) -> {
@@ -211,6 +200,72 @@ public class GroupService {
                             question != null ? question.getContent() : null,
                             question != null ? question.getCategory() : null,
                             r.getAnswerText(),
+                            user != null ? user.getStreakDays() : 0,
+                            user != null ? user.getTotalDays() : 0
+                    );
+                })
+                .toList();
+    }
+
+    private List<GroupTodayReflectionItem> getTodayReflectionsForFriendGroup(
+            Long groupId, Long userId, LocalDate today, GroupReflectionSort sort) {
+        List<Long> memberUserIds = groupMemberRepository.findAllByGroupIdAndDeletedAtIsNull(groupId)
+                .stream()
+                .map(GroupMemberEntity::getUserId)
+                .toList();
+
+        if (!groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)) {
+            throw new BusinessException(GroupErrorCode.GROUP_ACCESS_DENIED);
+        }
+
+        if (memberUserIds.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, UserEntity> userMap = userRepository.findAllById(memberUserIds)
+                .stream().collect(Collectors.toMap(UserEntity::getId, u -> u));
+
+        Map<Long, ReflectionEntity> reflectionByUserId = reflectionRepository.findAllByDateAndUserIdIn(today, memberUserIds)
+                .stream().collect(Collectors.toMap(ReflectionEntity::getUserId, r -> r));
+
+        List<Long> questionIds = reflectionByUserId.values().stream()
+                .map(ReflectionEntity::getQuestionId).distinct().toList();
+        Map<Long, ReflectionQuestionEntity> questionMap = questionIds.isEmpty() ? Map.of() :
+                reflectionQuestionRepository.findAllById(questionIds)
+                        .stream().collect(Collectors.toMap(ReflectionQuestionEntity::getId, q -> q));
+
+        Comparator<Long> comparator = switch (sort) {
+            case STREAK -> Comparator.comparingInt((Long uid) -> {
+                UserEntity u = userMap.get(uid);
+                return u != null ? u.getStreakDays() : 0;
+            }).reversed();
+            case TOTAL -> Comparator.comparingInt((Long uid) -> {
+                UserEntity u = userMap.get(uid);
+                return u != null ? u.getTotalDays() : 0;
+            }).reversed();
+            default -> (a, b) -> {
+                ReflectionEntity ra = reflectionByUserId.get(a);
+                ReflectionEntity rb = reflectionByUserId.get(b);
+                if (ra == null && rb == null) return 0;
+                if (ra == null) return 1;
+                if (rb == null) return -1;
+                return rb.getCreatedAt().compareTo(ra.getCreatedAt());
+            };
+        };
+
+        return memberUserIds.stream()
+                .sorted(comparator)
+                .map(uid -> {
+                    UserEntity user = userMap.get(uid);
+                    ReflectionEntity reflection = reflectionByUserId.get(uid);
+                    ReflectionQuestionEntity question = reflection != null ? questionMap.get(reflection.getQuestionId()) : null;
+                    return new GroupTodayReflectionItem(
+                            uid,
+                            user != null ? user.getNickname() : null,
+                            user != null ? user.getCategory() : null,
+                            question != null ? question.getContent() : null,
+                            question != null ? question.getCategory() : null,
+                            reflection != null ? reflection.getAnswerText() : null,
                             user != null ? user.getStreakDays() : 0,
                             user != null ? user.getTotalDays() : 0
                     );

--- a/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupServiceTest.java
+++ b/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupServiceTest.java
@@ -334,6 +334,63 @@ class GroupServiceTest {
     }
 
     @Test
+    void getTodayReflections_FRIEND_회고_안한_멤버도_포함() {
+        Long userId = 1L;
+        Long groupId = 10L;
+
+        GroupEntity groupEntity = mock(GroupEntity.class);
+        when(groupEntity.getType()).thenReturn(GroupType.FRIEND);
+        when(groupRepository.findByIdAndDeletedAtIsNull(groupId)).thenReturn(Optional.of(groupEntity));
+
+        GroupMemberEntity member1 = mock(GroupMemberEntity.class);
+        when(member1.getUserId()).thenReturn(1L);
+        GroupMemberEntity member2 = mock(GroupMemberEntity.class);
+        when(member2.getUserId()).thenReturn(2L);
+        when(groupMemberRepository.findAllByGroupIdAndDeletedAtIsNull(groupId)).thenReturn(List.of(member1, member2));
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)).thenReturn(true);
+
+        ReflectionEntity reflection = mock(ReflectionEntity.class);
+        when(reflection.getUserId()).thenReturn(1L);
+        when(reflection.getQuestionId()).thenReturn(100L);
+        when(reflection.getAnswerText()).thenReturn("회고 내용");
+        when(reflectionRepository.findAllByDateAndUserIdIn(any(LocalDate.class), anyList()))
+                .thenReturn(List.of(reflection));
+
+        ReflectionQuestionEntity question = mock(ReflectionQuestionEntity.class);
+        when(question.getId()).thenReturn(100L);
+        when(question.getContent()).thenReturn("오늘의 질문");
+        when(question.getCategory()).thenReturn(ZtpiCategory.FUTURE);
+        when(reflectionQuestionRepository.findAllById(anyList())).thenReturn(List.of(question));
+
+        UserEntity user1 = mock(UserEntity.class);
+        when(user1.getId()).thenReturn(1L);
+        when(user1.getNickname()).thenReturn("유저1");
+        when(user1.getStreakDays()).thenReturn(5);
+        when(user1.getTotalDays()).thenReturn(10);
+
+        UserEntity user2 = mock(UserEntity.class);
+        when(user2.getId()).thenReturn(2L);
+        when(user2.getNickname()).thenReturn("유저2");
+        when(user2.getStreakDays()).thenReturn(3);
+        when(user2.getTotalDays()).thenReturn(7);
+
+        when(userRepository.findAllById(anyList())).thenReturn(List.of(user1, user2));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            List<GroupTodayReflectionItem> result = groupService.getTodayReflections(groupId, GroupReflectionSort.LATEST);
+
+            assertThat(result).hasSize(2);
+            GroupTodayReflectionItem withReflection = result.stream().filter(r -> r.userId().equals(1L)).findFirst().orElseThrow();
+            GroupTodayReflectionItem withoutReflection = result.stream().filter(r -> r.userId().equals(2L)).findFirst().orElseThrow();
+            assertThat(withReflection.answerText()).isEqualTo("회고 내용");
+            assertThat(withoutReflection.answerText()).isNull();
+            assertThat(withoutReflection.questionContent()).isNull();
+        }
+    }
+
+    @Test
     void getTodayReflections_FRIEND_비멤버_403() {
         Long userId = 1L;
         Long groupId = 10L;


### PR DESCRIPTION
## Summary
- FRIEND 그룹의 `GET /groups/{groupId}/reflections/today` 에서 오늘 회고를 작성하지 않은 멤버가 응답에서 누락되는 버그 수정
- 기존: reflection 목록 기준으로 응답 구성 → 미작성자 제외
- 변경: 그룹 멤버 전체 기준으로 응답 구성, reflection이 없으면 `questionContent`, `questionCategory`, `answerText` = null
- CHARACTER 그룹 로직은 변경 없음

## Test plan
- [ ] 그룹 멤버 중 일부만 회고 시 전원 조회되는지 확인
- [ ] 미작성 멤버의 `answerText`, `questionContent`, `questionCategory` 가 null인지 확인
- [ ] 기존 `GroupServiceTest` 15개 전체 통과 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced reflection retrieval for friend groups to properly handle members who haven't submitted responses, displaying them with null values alongside submitted reflections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnd-side-project/dnd-14th-5-backend/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->