### PR TITLE
feat/user-service-feedback-api

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/user/application/service/UserServiceFeedbackService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/application/service/UserServiceFeedbackService.java
@@ -38,11 +38,12 @@ public class UserServiceFeedbackService {
             throw new BusinessException(UserServiceFeedbackErrorCode.ALREADY_EXISTS);
         }
 
-        UserServiceFeedback model = request.toModel();
+        UserServiceFeedback model = request.toModel(userId);
 
         userServiceFeedbackRepository.save(UserServiceFeedbackEntity.from(userEntity, model.serviceRating(), model.serviceFeedback()));
     }
 
+    @Transactional(readOnly = true)
     public List<UserServiceFeedbackResponse> findAll() {
         return userServiceFeedbackRepository.findByDeletedAtIsNull().stream()
                 .map(UserServiceFeedbackEntity::toModel)
@@ -52,7 +53,7 @@ public class UserServiceFeedbackService {
 
     @Transactional(readOnly = true)
     public UserServiceFeedbackDetailResponse findById(Long feedbackId) {
-        UserServiceFeedbackEntity userServiceFeedbackEntity = userServiceFeedbackRepository.findById(feedbackId)
+        UserServiceFeedbackEntity userServiceFeedbackEntity = userServiceFeedbackRepository.findByIdAndDeletedAtIsNull(feedbackId)
                 .orElseThrow(() -> new BusinessException(UserServiceFeedbackErrorCode.USER_SERVICE_FEEDBACK_NOT_FOUND));
 
         return UserServiceFeedbackDetailResponse.of(
@@ -62,7 +63,7 @@ public class UserServiceFeedbackService {
 
     @Transactional
     public void delete(Long feedbackId) {
-        UserServiceFeedbackEntity userServiceFeedbackEntity = userServiceFeedbackRepository.findById(feedbackId)
+        UserServiceFeedbackEntity userServiceFeedbackEntity = userServiceFeedbackRepository.findByIdAndDeletedAtIsNull(feedbackId)
                 .orElseThrow(() -> new BusinessException(UserServiceFeedbackErrorCode.USER_SERVICE_FEEDBACK_NOT_FOUND));
 
         userServiceFeedbackEntity.softDelete();

--- a/src/main/java/com/dnd5/timoapi/domain/user/application/service/UserServiceFeedbackService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/application/service/UserServiceFeedbackService.java
@@ -1,353 +1,71 @@
 package com.dnd5.timoapi.domain.user.application.service;
 
-import static com.dnd5.timoapi.global.security.context.SecurityUtil.getCurrentUserId;
-
-import com.dnd5.timoapi.domain.reflection.domain.entity.UserReflectionQuestionOrderEntity;
-import com.dnd5.timoapi.domain.reflection.domain.repository.UserReflectionQuestionOrderRepository;
-import com.dnd5.timoapi.domain.test.domain.entity.TestEntity;
-import com.dnd5.timoapi.domain.test.domain.entity.TestQuestionEntity;
-import com.dnd5.timoapi.domain.user.domain.entity.UserTestRecordEntity;
-import com.dnd5.timoapi.domain.user.domain.entity.UserTestResponseEntity;
-import com.dnd5.timoapi.domain.user.domain.entity.UserTestResultEntity;
-import com.dnd5.timoapi.domain.user.domain.model.UserTestRecord;
-import com.dnd5.timoapi.domain.user.domain.model.enums.UserTestRecordStatus;
-import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
-import com.dnd5.timoapi.domain.test.domain.repository.TestQuestionRepository;
-import com.dnd5.timoapi.domain.test.domain.repository.TestRepository;
-import com.dnd5.timoapi.domain.user.domain.repository.UserTestRecordRepository;
-import com.dnd5.timoapi.domain.user.domain.repository.UserTestResponseRepository;
-import com.dnd5.timoapi.domain.user.domain.repository.UserTestResultRepository;
-import com.dnd5.timoapi.domain.test.exception.TestErrorCode;
-import com.dnd5.timoapi.domain.test.exception.TestQuestionErrorCode;
-import com.dnd5.timoapi.domain.user.exception.UserTestRecordErrorCode;
-import com.dnd5.timoapi.domain.user.exception.UserTestResponseErrorCode;
-import com.dnd5.timoapi.domain.user.presentation.request.UserTestRecordCreateRequest;
-import com.dnd5.timoapi.domain.test.presentation.response.TestResultCategoryResponse;
-import com.dnd5.timoapi.domain.test.presentation.response.TestResultResponse;
-import com.dnd5.timoapi.domain.test.presentation.response.TestResultScoreResponse;
-import com.dnd5.timoapi.domain.user.presentation.response.UserTestRecordCreateResponse;
-import com.dnd5.timoapi.domain.user.presentation.response.UserTestRecordDetailResponse;
-import com.dnd5.timoapi.domain.user.presentation.response.UserTestRecordResponse;
-import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
-import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
+import com.dnd5.timoapi.domain.user.domain.entity.*;
+import com.dnd5.timoapi.domain.user.domain.model.UserServiceFeedback;
+import com.dnd5.timoapi.domain.user.domain.repository.*;
 import com.dnd5.timoapi.domain.user.exception.UserErrorCode;
+import com.dnd5.timoapi.domain.user.exception.UserServiceFeedbackErrorCode;
+import com.dnd5.timoapi.domain.user.presentation.request.UserServiceFeedbackCreateRequest;
+import com.dnd5.timoapi.domain.user.presentation.response.UserServiceFeedbackDetailResponse;
+import com.dnd5.timoapi.domain.user.presentation.response.UserServiceFeedbackResponse;
 import com.dnd5.timoapi.global.exception.BusinessException;
-import com.dnd5.timoapi.global.security.context.SecurityUtil;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import com.dnd5.timoapi.global.analytics.event.TestCompletedEvent;
-import com.dnd5.timoapi.global.analytics.event.TestStartedEvent;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.dnd5.timoapi.global.security.context.SecurityUtil.getCurrentUserId;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class UserTestRecordService {
+public class UserServiceFeedbackService {
 
-    private final ApplicationEventPublisher eventPublisher;
     private final UserRepository userRepository;
-    private final TestRepository testRepository;
+    private final UserServiceFeedbackRepository userServiceFeedbackRepository;
 
-    private final TestQuestionRepository testQuestionRepository;
-
-    private final UserTestResponseRepository userTestResponseRepository;
-    private final UserTestResultRepository userTestResultRepository;
-
-    private final UserTestRecordRepository userTestRecordRepository;
-    private final UserReflectionQuestionOrderRepository userReflectionQuestionOrderRepository;
-
-    public UserTestRecordCreateResponse create(UserTestRecordCreateRequest request) {
+    public void create(UserServiceFeedbackCreateRequest request) {
         Long userId = getCurrentUserId();
-
         if (userId == null) {
             throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
         }
+
         UserEntity userEntity = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        TestEntity testEntity = testRepository.findByIdAndDeletedAtIsNull(request.testId())
-                .orElseThrow(() -> new BusinessException(TestErrorCode.TEST_NOT_FOUND));
-
-        Optional<UserTestRecordEntity> userTestRecordEntity =
-                userTestRecordRepository
-                        .findByUserIdAndTestIdAndStatusAndDeletedAtIsNull(
-                                userId,
-                                testEntity.getId(),
-                                UserTestRecordStatus.IN_PROGRESS);
-
-        if (userTestRecordEntity.isPresent()) {
-            return UserTestRecordCreateResponse.from(userTestRecordEntity.get().toModel(), true);
+        if (userServiceFeedbackRepository.existsByUserIdAndDeletedAtIsNull(userId)) {
+            throw new BusinessException(UserServiceFeedbackErrorCode.ALREADY_EXISTS);
         }
 
-        UserTestRecord model = request.toModel();
+        UserServiceFeedback model = request.toModel();
 
-        UserTestRecordEntity savedEntity =
-                userTestRecordRepository.save(
-                        UserTestRecordEntity.from(userEntity, testEntity, model));
-
-        eventPublisher.publishEvent(new TestStartedEvent(userId, savedEntity.getId()));
-        return UserTestRecordCreateResponse.from(savedEntity.toModel(), false);
+        userServiceFeedbackRepository.save(UserServiceFeedbackEntity.from(userEntity, model.serviceRating(), model.serviceFeedback()));
     }
 
-    public UserTestRecordDetailResponse complete(Long testRecordId) {
-        UserTestRecordEntity userTestRecordEntity = getUserTestRecordEntity(testRecordId);
-        Long userId = userTestRecordEntity.getUser().getId();
-
-        if (userTestRecordEntity.isCompleted()) {
-            throw new BusinessException(UserTestRecordErrorCode.ALREADY_COMPLETED);
-        }
-
-        validateUserTestRecordOwnership(userTestRecordEntity);
-
-        List<TestQuestionEntity> testQuestionEntityList = testQuestionRepository.findByTestIdAndDeletedAtIsNull(
-                        userTestRecordEntity.getTest().getId());
-        if (testQuestionEntityList.isEmpty()) {
-            throw new BusinessException(TestQuestionErrorCode.TEST_QUESTION_NOT_FOUND);
-        }
-
-        List<UserTestResponseEntity> userTestResponseEntityList = userTestResponseRepository.findByUserTestRecordIdAndDeletedAtIsNull(
-                        testRecordId);
-        if (userTestResponseEntityList.isEmpty()) {
-            throw new BusinessException(UserTestResponseErrorCode.USER_TEST_RESPONSE_NOT_FOUND);
-        }
-
-        validateNoDuplicateQuestionsAnswered(userTestResponseEntityList);
-
-        validateAllQuestionsAnswered(testQuestionEntityList, userTestResponseEntityList);
-        Map<ZtpiCategory, Double> userTestResults = createUserTestResults(userTestRecordEntity,
-                userTestResponseEntityList);
-
-        userTestRecordEntity.complete();
-        eventPublisher.publishEvent(new TestCompletedEvent(userId, testRecordId, userTestResults));
-
-        UserEntity userEntity = userTestRecordEntity.getUser();
-
-        ZtpiCategory userMaxCategory = calculateClosestCategory(userTestResults);
-        userEntity.updateZtpiCategory(userMaxCategory);
-
-        createUserReflectionQuestionOrders(userTestRecordEntity.getUser().getId());
-
-        if (!userEntity.getIsOnboarded()) {
-            userEntity.completeOnboarding();
-        }
-
-        TestResultResponse resultResponse = createTestResultResponse(userTestResults);
-
-        return UserTestRecordDetailResponse.of(
-                userTestRecordEntity.toModel(),
-                null,
-                resultResponse
-        );
-    }
-
-    @Transactional
-    public void delete(Long testRecordId) {
-        UserTestRecordEntity userTestRecordEntity = userTestRecordRepository.findByIdAndDeletedAtIsNull(testRecordId)
-                .orElseThrow(() -> new BusinessException(UserTestRecordErrorCode.USER_TEST_RECORD_NOT_FOUND));
-
-        List<UserTestResponseEntity> userTestResponseEntityList =
-                userTestResponseRepository.findAllByUserTestRecordIdAndDeletedAtIsNull(testRecordId);
-
-        userTestResponseEntityList.forEach(UserTestResponseEntity::softDelete);
-
-        List<UserTestResultEntity> userTestResultEntityList =
-                userTestResultRepository.findAllByUserTestRecordIdAndDeletedAtIsNull(testRecordId);
-
-        userTestResultEntityList.forEach(UserTestResultEntity::softDelete);
-
-        userTestRecordEntity.softDelete();
-    }
-
-    private ZtpiCategory calculateClosestCategory(
-            Map<ZtpiCategory, Double> userTestResults) {
-        return userTestResults.entrySet().stream()
-                // 이상 점수보다 큰 것만
-                .filter(e -> e.getValue() > e.getKey().getIdealScore())
-                // 초과폭 큰 순
-                .max(Comparator.comparingDouble(e ->
-                        e.getValue() - e.getKey().getIdealScore()
-                ))
-                .map(Map.Entry::getKey)
-                // 전부 이상 이하일 경우 fallback
-                .orElseGet(() ->
-                        userTestResults.entrySet().stream()
-                                .max(Map.Entry.comparingByValue())
-                                .map(Map.Entry::getKey)
-                                .orElseThrow()
-                );
-    }
-
-    private List<TestResultScoreResponse> createScoreResponse(
-            Map<ZtpiCategory, Double> userTestResults) {
-        return userTestResults.entrySet().stream()
-                .map(entry -> {
-
-                    ZtpiCategory category = entry.getKey();
-                    double score = entry.getValue();
-
-                    return new TestResultScoreResponse(
-                            category,
-                            score,
-                            category.getIdealScore()
-                    );
-                })
+    public List<UserServiceFeedbackResponse> findAll() {
+        return userServiceFeedbackRepository.findByDeletedAtIsNull().stream()
+                .map(UserServiceFeedbackEntity::toModel)
+                .map(UserServiceFeedbackResponse::from)
                 .toList();
     }
 
     @Transactional(readOnly = true)
-    public List<UserTestRecordResponse> findAll() {
-        Long userId = getCurrentUserId();
+    public UserServiceFeedbackDetailResponse findById(Long feedbackId) {
+        UserServiceFeedbackEntity userServiceFeedbackEntity = userServiceFeedbackRepository.findById(feedbackId)
+                .orElseThrow(() -> new BusinessException(UserServiceFeedbackErrorCode.USER_SERVICE_FEEDBACK_NOT_FOUND));
 
-        if (userId == null) {
-            throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
-        }
-
-        return userTestRecordRepository.findByUserIdAndDeletedAtIsNull(userId).stream()
-                .map(UserTestRecordEntity::toModel)
-                .map(UserTestRecordResponse::from)
-                .toList();
-    }
-
-    @Transactional(readOnly = true)
-    public UserTestRecordDetailResponse findById(Long testRecordId) {
-        UserTestRecordEntity userTestRecordEntity = getUserTestRecordEntity(testRecordId);
-        int progress =
-                userTestResponseRepository.countByUserTestRecordIdAndDeletedAtIsNull(testRecordId);
-
-        if (!userTestRecordEntity.isCompleted()) {
-            return UserTestRecordDetailResponse.of(
-                    userTestRecordEntity.toModel(),
-                    progress,
-                    null
-            );
-        }
-
-        List<UserTestResultEntity> resultEntities =
-                userTestResultRepository.findAllByUserTestRecordIdAndDeletedAtIsNull(testRecordId);
-
-        if (resultEntities.isEmpty()) {
-            throw new BusinessException(UserTestRecordErrorCode.USER_TEST_RESULT_NOT_FOUND);
-        }
-
-        Map<ZtpiCategory, Double> userTestResults = resultEntities.stream()
-                .collect(Collectors.toMap(
-                        UserTestResultEntity::getCategory,
-                        UserTestResultEntity::getScore
-                ));
-
-        TestResultResponse resultResponse = createTestResultResponse(userTestResults);
-
-        return UserTestRecordDetailResponse.of(
-                userTestRecordEntity.toModel(),
-                null,
-                resultResponse
+        return UserServiceFeedbackDetailResponse.of(
+                userServiceFeedbackEntity.toModel()
         );
-    }
-
-    private TestResultResponse createTestResultResponse(
-            Map<ZtpiCategory, Double> userTestResults) {
-        List<TestResultScoreResponse> scoreResponses = createScoreResponse(userTestResults);
-        ZtpiCategory closestCategory = calculateClosestCategory(userTestResults);
-
-        return new TestResultResponse(
-                new TestResultCategoryResponse(
-                        closestCategory.name(),
-                        closestCategory.getCharacter(),
-                        closestCategory.getPersonality(),
-                        closestCategory.getDescription()
-                ),
-                scoreResponses
-        );
-    }
-
-    private UserTestRecordEntity getUserTestRecordEntity(Long testRecordId) {
-        return userTestRecordRepository.findByIdAndDeletedAtIsNull(testRecordId)
-                .orElseThrow(() -> new BusinessException(
-                        UserTestRecordErrorCode.USER_TEST_RECORD_NOT_FOUND));
-    }
-
-    private void createUserReflectionQuestionOrders(Long userId) {
-        for (ZtpiCategory category : ZtpiCategory.values()) {
-            if (!userReflectionQuestionOrderRepository.existsByUserIdAndCategory(userId,
-                    category)) {
-                userReflectionQuestionOrderRepository.save(
-                        new UserReflectionQuestionOrderEntity(userId, category, 1L)
-                );
-            }
-        }
-    }
-
-    private void validateAllQuestionsAnswered(List<TestQuestionEntity> testQuestionEntityList,
-            List<UserTestResponseEntity> userTestResponseEntityList) {
-        if (testQuestionEntityList.size() > userTestResponseEntityList.size()) {
-            throw new BusinessException(UserTestRecordErrorCode.NOT_ALL_QUESTIONS_ANSWERED);
-        }
-    }
-
-    private void validateNoDuplicateQuestionsAnswered(List<UserTestResponseEntity> responses) {
-        long distinctCount = responses.stream()
-                .map(response -> response.getTestQuestion().getId())
-                .distinct()
-                .count();
-
-        if (distinctCount != responses.size()) {
-            throw new BusinessException(UserTestRecordErrorCode.DUPLICATE_QUESTION_RESPONSE);
-        }
-    }
-
-    private void validateUserTestRecordOwnership(UserTestRecordEntity record) {
-        Long currentUserId = SecurityUtil.getCurrentUserId();
-        if (!record.getUser().getId().equals(currentUserId)) {
-            throw new BusinessException(UserTestRecordErrorCode.USER_TEST_NOT_OWNER,
-                    record.getId(), record.getUser().getId(), currentUserId);
-        }
-    }
-
-    private Map<ZtpiCategory, Double> calculateCategoryAverages(
-            List<UserTestResponseEntity> userTestResponseEntityList) {
-        return userTestResponseEntityList.stream()
-                .collect(Collectors.groupingBy(
-                        r -> r.getTestQuestion().getCategory(),
-                        Collectors.averagingDouble(UserTestResponseEntity::getScore)
-                ));
     }
 
     @Transactional
-    public Map<ZtpiCategory, Double> createUserTestResults(
-            UserTestRecordEntity userTestRecordEntity,
-            List<UserTestResponseEntity> userTestResponseEntityList) {
-        Map<ZtpiCategory, Double> userTestCategoryAverages = calculateCategoryAverages(
-                userTestResponseEntityList);
+    public void delete(Long feedbackId) {
+        UserServiceFeedbackEntity userServiceFeedbackEntity = userServiceFeedbackRepository.findById(feedbackId)
+                .orElseThrow(() -> new BusinessException(UserServiceFeedbackErrorCode.USER_SERVICE_FEEDBACK_NOT_FOUND));
 
-        List<UserTestResultEntity> userTestResultEntityList = userTestCategoryAverages.entrySet()
-                .stream()
-                .map(entry -> UserTestResultEntity.from(userTestRecordEntity, entry.getKey(),
-                        entry.getValue()))
-                .collect(Collectors.toList());
-        userTestResultRepository.saveAll(userTestResultEntityList);
-
-        return userTestCategoryAverages;
+        userServiceFeedbackEntity.softDelete();
     }
 
-    public ZtpiCategory getUserTestRecordMaxCategory(Long testRecordId) {
-
-        List<UserTestResultEntity> results =
-                userTestResultRepository.findAllByUserTestRecordIdAndDeletedAtIsNull(testRecordId);
-
-        if (results.isEmpty()) {
-            throw new BusinessException(UserTestRecordErrorCode.USER_TEST_RESULT_NOT_FOUND);
-        }
-
-        return results.stream()
-                .max(Comparator.comparing(UserTestResultEntity::getScore))
-                .orElseThrow(() -> new BusinessException(
-                        UserTestRecordErrorCode.USER_TEST_RESULT_NOT_FOUND))
-                .getCategory();
-    }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/user/application/service/UserServiceFeedbackService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/application/service/UserServiceFeedbackService.java
@@ -1,0 +1,353 @@
+package com.dnd5.timoapi.domain.user.application.service;
+
+import static com.dnd5.timoapi.global.security.context.SecurityUtil.getCurrentUserId;
+
+import com.dnd5.timoapi.domain.reflection.domain.entity.UserReflectionQuestionOrderEntity;
+import com.dnd5.timoapi.domain.reflection.domain.repository.UserReflectionQuestionOrderRepository;
+import com.dnd5.timoapi.domain.test.domain.entity.TestEntity;
+import com.dnd5.timoapi.domain.test.domain.entity.TestQuestionEntity;
+import com.dnd5.timoapi.domain.user.domain.entity.UserTestRecordEntity;
+import com.dnd5.timoapi.domain.user.domain.entity.UserTestResponseEntity;
+import com.dnd5.timoapi.domain.user.domain.entity.UserTestResultEntity;
+import com.dnd5.timoapi.domain.user.domain.model.UserTestRecord;
+import com.dnd5.timoapi.domain.user.domain.model.enums.UserTestRecordStatus;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+import com.dnd5.timoapi.domain.test.domain.repository.TestQuestionRepository;
+import com.dnd5.timoapi.domain.test.domain.repository.TestRepository;
+import com.dnd5.timoapi.domain.user.domain.repository.UserTestRecordRepository;
+import com.dnd5.timoapi.domain.user.domain.repository.UserTestResponseRepository;
+import com.dnd5.timoapi.domain.user.domain.repository.UserTestResultRepository;
+import com.dnd5.timoapi.domain.test.exception.TestErrorCode;
+import com.dnd5.timoapi.domain.test.exception.TestQuestionErrorCode;
+import com.dnd5.timoapi.domain.user.exception.UserTestRecordErrorCode;
+import com.dnd5.timoapi.domain.user.exception.UserTestResponseErrorCode;
+import com.dnd5.timoapi.domain.user.presentation.request.UserTestRecordCreateRequest;
+import com.dnd5.timoapi.domain.test.presentation.response.TestResultCategoryResponse;
+import com.dnd5.timoapi.domain.test.presentation.response.TestResultResponse;
+import com.dnd5.timoapi.domain.test.presentation.response.TestResultScoreResponse;
+import com.dnd5.timoapi.domain.user.presentation.response.UserTestRecordCreateResponse;
+import com.dnd5.timoapi.domain.user.presentation.response.UserTestRecordDetailResponse;
+import com.dnd5.timoapi.domain.user.presentation.response.UserTestRecordResponse;
+import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
+import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
+import com.dnd5.timoapi.domain.user.exception.UserErrorCode;
+import com.dnd5.timoapi.global.exception.BusinessException;
+import com.dnd5.timoapi.global.security.context.SecurityUtil;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import com.dnd5.timoapi.global.analytics.event.TestCompletedEvent;
+import com.dnd5.timoapi.global.analytics.event.TestStartedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserTestRecordService {
+
+    private final ApplicationEventPublisher eventPublisher;
+    private final UserRepository userRepository;
+    private final TestRepository testRepository;
+
+    private final TestQuestionRepository testQuestionRepository;
+
+    private final UserTestResponseRepository userTestResponseRepository;
+    private final UserTestResultRepository userTestResultRepository;
+
+    private final UserTestRecordRepository userTestRecordRepository;
+    private final UserReflectionQuestionOrderRepository userReflectionQuestionOrderRepository;
+
+    public UserTestRecordCreateResponse create(UserTestRecordCreateRequest request) {
+        Long userId = getCurrentUserId();
+
+        if (userId == null) {
+            throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
+        }
+        UserEntity userEntity = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        TestEntity testEntity = testRepository.findByIdAndDeletedAtIsNull(request.testId())
+                .orElseThrow(() -> new BusinessException(TestErrorCode.TEST_NOT_FOUND));
+
+        Optional<UserTestRecordEntity> userTestRecordEntity =
+                userTestRecordRepository
+                        .findByUserIdAndTestIdAndStatusAndDeletedAtIsNull(
+                                userId,
+                                testEntity.getId(),
+                                UserTestRecordStatus.IN_PROGRESS);
+
+        if (userTestRecordEntity.isPresent()) {
+            return UserTestRecordCreateResponse.from(userTestRecordEntity.get().toModel(), true);
+        }
+
+        UserTestRecord model = request.toModel();
+
+        UserTestRecordEntity savedEntity =
+                userTestRecordRepository.save(
+                        UserTestRecordEntity.from(userEntity, testEntity, model));
+
+        eventPublisher.publishEvent(new TestStartedEvent(userId, savedEntity.getId()));
+        return UserTestRecordCreateResponse.from(savedEntity.toModel(), false);
+    }
+
+    public UserTestRecordDetailResponse complete(Long testRecordId) {
+        UserTestRecordEntity userTestRecordEntity = getUserTestRecordEntity(testRecordId);
+        Long userId = userTestRecordEntity.getUser().getId();
+
+        if (userTestRecordEntity.isCompleted()) {
+            throw new BusinessException(UserTestRecordErrorCode.ALREADY_COMPLETED);
+        }
+
+        validateUserTestRecordOwnership(userTestRecordEntity);
+
+        List<TestQuestionEntity> testQuestionEntityList = testQuestionRepository.findByTestIdAndDeletedAtIsNull(
+                        userTestRecordEntity.getTest().getId());
+        if (testQuestionEntityList.isEmpty()) {
+            throw new BusinessException(TestQuestionErrorCode.TEST_QUESTION_NOT_FOUND);
+        }
+
+        List<UserTestResponseEntity> userTestResponseEntityList = userTestResponseRepository.findByUserTestRecordIdAndDeletedAtIsNull(
+                        testRecordId);
+        if (userTestResponseEntityList.isEmpty()) {
+            throw new BusinessException(UserTestResponseErrorCode.USER_TEST_RESPONSE_NOT_FOUND);
+        }
+
+        validateNoDuplicateQuestionsAnswered(userTestResponseEntityList);
+
+        validateAllQuestionsAnswered(testQuestionEntityList, userTestResponseEntityList);
+        Map<ZtpiCategory, Double> userTestResults = createUserTestResults(userTestRecordEntity,
+                userTestResponseEntityList);
+
+        userTestRecordEntity.complete();
+        eventPublisher.publishEvent(new TestCompletedEvent(userId, testRecordId, userTestResults));
+
+        UserEntity userEntity = userTestRecordEntity.getUser();
+
+        ZtpiCategory userMaxCategory = calculateClosestCategory(userTestResults);
+        userEntity.updateZtpiCategory(userMaxCategory);
+
+        createUserReflectionQuestionOrders(userTestRecordEntity.getUser().getId());
+
+        if (!userEntity.getIsOnboarded()) {
+            userEntity.completeOnboarding();
+        }
+
+        TestResultResponse resultResponse = createTestResultResponse(userTestResults);
+
+        return UserTestRecordDetailResponse.of(
+                userTestRecordEntity.toModel(),
+                null,
+                resultResponse
+        );
+    }
+
+    @Transactional
+    public void delete(Long testRecordId) {
+        UserTestRecordEntity userTestRecordEntity = userTestRecordRepository.findByIdAndDeletedAtIsNull(testRecordId)
+                .orElseThrow(() -> new BusinessException(UserTestRecordErrorCode.USER_TEST_RECORD_NOT_FOUND));
+
+        List<UserTestResponseEntity> userTestResponseEntityList =
+                userTestResponseRepository.findAllByUserTestRecordIdAndDeletedAtIsNull(testRecordId);
+
+        userTestResponseEntityList.forEach(UserTestResponseEntity::softDelete);
+
+        List<UserTestResultEntity> userTestResultEntityList =
+                userTestResultRepository.findAllByUserTestRecordIdAndDeletedAtIsNull(testRecordId);
+
+        userTestResultEntityList.forEach(UserTestResultEntity::softDelete);
+
+        userTestRecordEntity.softDelete();
+    }
+
+    private ZtpiCategory calculateClosestCategory(
+            Map<ZtpiCategory, Double> userTestResults) {
+        return userTestResults.entrySet().stream()
+                // 이상 점수보다 큰 것만
+                .filter(e -> e.getValue() > e.getKey().getIdealScore())
+                // 초과폭 큰 순
+                .max(Comparator.comparingDouble(e ->
+                        e.getValue() - e.getKey().getIdealScore()
+                ))
+                .map(Map.Entry::getKey)
+                // 전부 이상 이하일 경우 fallback
+                .orElseGet(() ->
+                        userTestResults.entrySet().stream()
+                                .max(Map.Entry.comparingByValue())
+                                .map(Map.Entry::getKey)
+                                .orElseThrow()
+                );
+    }
+
+    private List<TestResultScoreResponse> createScoreResponse(
+            Map<ZtpiCategory, Double> userTestResults) {
+        return userTestResults.entrySet().stream()
+                .map(entry -> {
+
+                    ZtpiCategory category = entry.getKey();
+                    double score = entry.getValue();
+
+                    return new TestResultScoreResponse(
+                            category,
+                            score,
+                            category.getIdealScore()
+                    );
+                })
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserTestRecordResponse> findAll() {
+        Long userId = getCurrentUserId();
+
+        if (userId == null) {
+            throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
+        }
+
+        return userTestRecordRepository.findByUserIdAndDeletedAtIsNull(userId).stream()
+                .map(UserTestRecordEntity::toModel)
+                .map(UserTestRecordResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public UserTestRecordDetailResponse findById(Long testRecordId) {
+        UserTestRecordEntity userTestRecordEntity = getUserTestRecordEntity(testRecordId);
+        int progress =
+                userTestResponseRepository.countByUserTestRecordIdAndDeletedAtIsNull(testRecordId);
+
+        if (!userTestRecordEntity.isCompleted()) {
+            return UserTestRecordDetailResponse.of(
+                    userTestRecordEntity.toModel(),
+                    progress,
+                    null
+            );
+        }
+
+        List<UserTestResultEntity> resultEntities =
+                userTestResultRepository.findAllByUserTestRecordIdAndDeletedAtIsNull(testRecordId);
+
+        if (resultEntities.isEmpty()) {
+            throw new BusinessException(UserTestRecordErrorCode.USER_TEST_RESULT_NOT_FOUND);
+        }
+
+        Map<ZtpiCategory, Double> userTestResults = resultEntities.stream()
+                .collect(Collectors.toMap(
+                        UserTestResultEntity::getCategory,
+                        UserTestResultEntity::getScore
+                ));
+
+        TestResultResponse resultResponse = createTestResultResponse(userTestResults);
+
+        return UserTestRecordDetailResponse.of(
+                userTestRecordEntity.toModel(),
+                null,
+                resultResponse
+        );
+    }
+
+    private TestResultResponse createTestResultResponse(
+            Map<ZtpiCategory, Double> userTestResults) {
+        List<TestResultScoreResponse> scoreResponses = createScoreResponse(userTestResults);
+        ZtpiCategory closestCategory = calculateClosestCategory(userTestResults);
+
+        return new TestResultResponse(
+                new TestResultCategoryResponse(
+                        closestCategory.name(),
+                        closestCategory.getCharacter(),
+                        closestCategory.getPersonality(),
+                        closestCategory.getDescription()
+                ),
+                scoreResponses
+        );
+    }
+
+    private UserTestRecordEntity getUserTestRecordEntity(Long testRecordId) {
+        return userTestRecordRepository.findByIdAndDeletedAtIsNull(testRecordId)
+                .orElseThrow(() -> new BusinessException(
+                        UserTestRecordErrorCode.USER_TEST_RECORD_NOT_FOUND));
+    }
+
+    private void createUserReflectionQuestionOrders(Long userId) {
+        for (ZtpiCategory category : ZtpiCategory.values()) {
+            if (!userReflectionQuestionOrderRepository.existsByUserIdAndCategory(userId,
+                    category)) {
+                userReflectionQuestionOrderRepository.save(
+                        new UserReflectionQuestionOrderEntity(userId, category, 1L)
+                );
+            }
+        }
+    }
+
+    private void validateAllQuestionsAnswered(List<TestQuestionEntity> testQuestionEntityList,
+            List<UserTestResponseEntity> userTestResponseEntityList) {
+        if (testQuestionEntityList.size() > userTestResponseEntityList.size()) {
+            throw new BusinessException(UserTestRecordErrorCode.NOT_ALL_QUESTIONS_ANSWERED);
+        }
+    }
+
+    private void validateNoDuplicateQuestionsAnswered(List<UserTestResponseEntity> responses) {
+        long distinctCount = responses.stream()
+                .map(response -> response.getTestQuestion().getId())
+                .distinct()
+                .count();
+
+        if (distinctCount != responses.size()) {
+            throw new BusinessException(UserTestRecordErrorCode.DUPLICATE_QUESTION_RESPONSE);
+        }
+    }
+
+    private void validateUserTestRecordOwnership(UserTestRecordEntity record) {
+        Long currentUserId = SecurityUtil.getCurrentUserId();
+        if (!record.getUser().getId().equals(currentUserId)) {
+            throw new BusinessException(UserTestRecordErrorCode.USER_TEST_NOT_OWNER,
+                    record.getId(), record.getUser().getId(), currentUserId);
+        }
+    }
+
+    private Map<ZtpiCategory, Double> calculateCategoryAverages(
+            List<UserTestResponseEntity> userTestResponseEntityList) {
+        return userTestResponseEntityList.stream()
+                .collect(Collectors.groupingBy(
+                        r -> r.getTestQuestion().getCategory(),
+                        Collectors.averagingDouble(UserTestResponseEntity::getScore)
+                ));
+    }
+
+    @Transactional
+    public Map<ZtpiCategory, Double> createUserTestResults(
+            UserTestRecordEntity userTestRecordEntity,
+            List<UserTestResponseEntity> userTestResponseEntityList) {
+        Map<ZtpiCategory, Double> userTestCategoryAverages = calculateCategoryAverages(
+                userTestResponseEntityList);
+
+        List<UserTestResultEntity> userTestResultEntityList = userTestCategoryAverages.entrySet()
+                .stream()
+                .map(entry -> UserTestResultEntity.from(userTestRecordEntity, entry.getKey(),
+                        entry.getValue()))
+                .collect(Collectors.toList());
+        userTestResultRepository.saveAll(userTestResultEntityList);
+
+        return userTestCategoryAverages;
+    }
+
+    public ZtpiCategory getUserTestRecordMaxCategory(Long testRecordId) {
+
+        List<UserTestResultEntity> results =
+                userTestResultRepository.findAllByUserTestRecordIdAndDeletedAtIsNull(testRecordId);
+
+        if (results.isEmpty()) {
+            throw new BusinessException(UserTestRecordErrorCode.USER_TEST_RESULT_NOT_FOUND);
+        }
+
+        return results.stream()
+                .max(Comparator.comparing(UserTestResultEntity::getScore))
+                .orElseThrow(() -> new BusinessException(
+                        UserTestRecordErrorCode.USER_TEST_RESULT_NOT_FOUND))
+                .getCategory();
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/user/domain/entity/UserServiceFeedbackEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/domain/entity/UserServiceFeedbackEntity.java
@@ -1,0 +1,51 @@
+package com.dnd5.timoapi.domain.user.domain.entity;
+
+import com.dnd5.timoapi.domain.user.domain.model.UserServiceFeedback;
+import com.dnd5.timoapi.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(name = "user_service_feedbacks")
+public class UserServiceFeedbackEntity extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    @Column(nullable = false)
+    private Long serviceRating;
+
+    @Column(nullable = false)
+    private String serviceFeedback;
+
+    public static UserServiceFeedbackEntity from(
+            UserEntity user,
+            Long serviceRating,
+            String serviceFeedback
+    ) {
+        return new UserServiceFeedbackEntity(
+                user,
+                serviceRating,
+                serviceFeedback
+        );
+    }
+
+    public UserServiceFeedback toModel() {
+        return new UserServiceFeedback(
+                getId(),
+                user.getId(),
+                getServiceRating(),
+                getServiceFeedback(),
+                getCreatedAt(),
+                getUpdatedAt()
+        );
+    }
+
+}

--- a/src/main/java/com/dnd5/timoapi/domain/user/domain/model/UserServiceFeedback.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/domain/model/UserServiceFeedback.java
@@ -1,0 +1,29 @@
+package com.dnd5.timoapi.domain.user.domain.model;
+
+import java.time.LocalDateTime;
+
+import static com.dnd5.timoapi.global.security.context.SecurityUtil.getCurrentUserId;
+
+public record UserServiceFeedback(
+        Long id,
+        Long userId,
+        Long serviceRating,
+        String serviceFeedback,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static UserServiceFeedback create(
+            Long serviceRating,
+            String serviceFeedback
+    ) {
+        return new UserServiceFeedback(
+                null,
+                getCurrentUserId(),
+                serviceRating,
+                serviceFeedback,
+                null,
+                null
+        );
+    }
+
+}

--- a/src/main/java/com/dnd5/timoapi/domain/user/domain/model/UserServiceFeedback.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/domain/model/UserServiceFeedback.java
@@ -13,12 +13,13 @@ public record UserServiceFeedback(
         LocalDateTime updatedAt
 ) {
     public static UserServiceFeedback create(
+            Long userId,
             Long serviceRating,
             String serviceFeedback
     ) {
         return new UserServiceFeedback(
                 null,
-                getCurrentUserId(),
+                userId,
                 serviceRating,
                 serviceFeedback,
                 null,

--- a/src/main/java/com/dnd5/timoapi/domain/user/domain/repository/UserServiceFeedbackRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/domain/repository/UserServiceFeedbackRepository.java
@@ -1,0 +1,14 @@
+package com.dnd5.timoapi.domain.user.domain.repository;
+
+import com.dnd5.timoapi.domain.user.domain.entity.UserServiceFeedbackEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserServiceFeedbackRepository extends JpaRepository<UserServiceFeedbackEntity, Long> {
+    Optional<UserServiceFeedbackEntity> findByIdAndDeletedAtIsNull(Long id);
+    List<UserServiceFeedbackEntity> findByDeletedAtIsNull();
+
+    boolean existsByUserIdAndDeletedAtIsNull(Long userId);
+}

--- a/src/main/java/com/dnd5/timoapi/domain/user/exception/UserServiceFeedbackErrorCode.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/exception/UserServiceFeedbackErrorCode.java
@@ -1,0 +1,18 @@
+package com.dnd5.timoapi.domain.user.exception;
+
+import com.dnd5.timoapi.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserServiceFeedbackErrorCode implements ErrorCode {
+
+    USER_SERVICE_FEEDBACK_NOT_FOUND(HttpStatus.NOT_FOUND, "유저의 서비스 피드백을 찾을 수 없습니다."),
+    ALREADY_EXISTS(HttpStatus.CONFLICT, "유저의 서비스 피드백이 이미 존재합니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/dnd5/timoapi/domain/user/presentation/AdminUserServiceFeedbackController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/presentation/AdminUserServiceFeedbackController.java
@@ -1,11 +1,8 @@
 package com.dnd5.timoapi.domain.user.presentation;
 
 import com.dnd5.timoapi.domain.user.application.service.UserServiceFeedbackService;
-import com.dnd5.timoapi.domain.user.application.service.UserTestRecordService;
-import com.dnd5.timoapi.domain.user.presentation.request.UserServiceFeedbackCreateRequest;
-import com.dnd5.timoapi.domain.user.presentation.request.UserTestRecordCreateRequest;
-import com.dnd5.timoapi.domain.user.presentation.response.*;
-import jakarta.validation.Valid;
+import com.dnd5.timoapi.domain.user.presentation.response.UserServiceFeedbackDetailResponse;
+import com.dnd5.timoapi.domain.user.presentation.response.UserServiceFeedbackResponse;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,20 +12,12 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/service-feedbacks")
+@RequestMapping("/admin/service-feedbacks")
 @RequiredArgsConstructor
 @Validated
-public class UserServiceFeedbackController {
+public class AdminUserServiceFeedbackController {
 
     private final UserServiceFeedbackService userServiceFeedbackService;
-
-    @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    public void create(
-            @Valid @RequestBody UserServiceFeedbackCreateRequest request
-    ) {
-        userServiceFeedbackService.create(request);
-    }
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/dnd5/timoapi/domain/user/presentation/AdminUserServiceFeedbackController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/presentation/AdminUserServiceFeedbackController.java
@@ -1,0 +1,55 @@
+package com.dnd5.timoapi.domain.user.presentation;
+
+import com.dnd5.timoapi.domain.user.application.service.UserServiceFeedbackService;
+import com.dnd5.timoapi.domain.user.application.service.UserTestRecordService;
+import com.dnd5.timoapi.domain.user.presentation.request.UserServiceFeedbackCreateRequest;
+import com.dnd5.timoapi.domain.user.presentation.request.UserTestRecordCreateRequest;
+import com.dnd5.timoapi.domain.user.presentation.response.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/service-feedbacks")
+@RequiredArgsConstructor
+@Validated
+public class UserServiceFeedbackController {
+
+    private final UserServiceFeedbackService userServiceFeedbackService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public void create(
+            @Valid @RequestBody UserServiceFeedbackCreateRequest request
+    ) {
+        userServiceFeedbackService.create(request);
+    }
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public List<UserServiceFeedbackResponse> findAll() {
+        return userServiceFeedbackService.findAll();
+    }
+
+    @GetMapping("/{feedbackId}")
+    @ResponseStatus(HttpStatus.OK)
+    public UserServiceFeedbackDetailResponse findById(
+            @Positive @PathVariable Long feedbackId
+    ) {
+        return userServiceFeedbackService.findById(feedbackId);
+    }
+
+    @DeleteMapping("/{feedbackId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(
+            @Positive @PathVariable Long feedbackId
+    ) {
+        userServiceFeedbackService.delete(feedbackId);
+    }
+
+}

--- a/src/main/java/com/dnd5/timoapi/domain/user/presentation/UserServiceFeedbackController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/presentation/UserServiceFeedbackController.java
@@ -1,70 +1,28 @@
 package com.dnd5.timoapi.domain.user.presentation;
 
-import com.dnd5.timoapi.domain.user.application.service.UserTestRecordService;
-import com.dnd5.timoapi.domain.user.presentation.request.UserTestRecordCreateRequest;
-import com.dnd5.timoapi.domain.user.presentation.response.UserTestRecordCreateResponse;
-import com.dnd5.timoapi.domain.user.presentation.response.UserTestRecordDetailResponse;
-import com.dnd5.timoapi.domain.user.presentation.response.UserTestRecordResponse;
+import com.dnd5.timoapi.domain.user.application.service.UserServiceFeedbackService;
+import com.dnd5.timoapi.domain.user.presentation.request.UserServiceFeedbackCreateRequest;
+import com.dnd5.timoapi.domain.user.presentation.response.*;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/test-records")
+@RequestMapping("/service-feedbacks")
 @RequiredArgsConstructor
 @Validated
-public class UserTestRecordController {
+public class UserServiceFeedbackController {
 
-    private final UserTestRecordService userTestRecordService;
+    private final UserServiceFeedbackService userServiceFeedbackService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public UserTestRecordCreateResponse create(
-            @Valid @RequestBody UserTestRecordCreateRequest request
+    public void create(
+            @Valid @RequestBody UserServiceFeedbackCreateRequest request
     ) {
-        return userTestRecordService.create(request);
-    }
-
-    @PatchMapping("/{testRecordId}/complete")
-    public UserTestRecordDetailResponse complete(
-            @Positive @PathVariable Long testRecordId
-    ) {
-        return userTestRecordService.complete(testRecordId);
-    }
-
-    @GetMapping("/me")
-    @ResponseStatus(HttpStatus.OK)
-    public List<UserTestRecordResponse> findAll() {
-        return userTestRecordService.findAll();
-    }
-
-    @GetMapping("/{testRecordId}")
-    @ResponseStatus(HttpStatus.OK)
-    public UserTestRecordDetailResponse findById(
-            @Positive @PathVariable Long testRecordId
-    ) {
-        return userTestRecordService.findById(testRecordId);
-    }
-
-    @DeleteMapping("/{testRecordId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(
-            @Positive @PathVariable Long testRecordId
-    ) {
-        userTestRecordService.delete(testRecordId);
+        userServiceFeedbackService.create(request);
     }
 
 }

--- a/src/main/java/com/dnd5/timoapi/domain/user/presentation/UserServiceFeedbackController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/presentation/UserServiceFeedbackController.java
@@ -1,0 +1,70 @@
+package com.dnd5.timoapi.domain.user.presentation;
+
+import com.dnd5.timoapi.domain.user.application.service.UserTestRecordService;
+import com.dnd5.timoapi.domain.user.presentation.request.UserTestRecordCreateRequest;
+import com.dnd5.timoapi.domain.user.presentation.response.UserTestRecordCreateResponse;
+import com.dnd5.timoapi.domain.user.presentation.response.UserTestRecordDetailResponse;
+import com.dnd5.timoapi.domain.user.presentation.response.UserTestRecordResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/test-records")
+@RequiredArgsConstructor
+@Validated
+public class UserTestRecordController {
+
+    private final UserTestRecordService userTestRecordService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public UserTestRecordCreateResponse create(
+            @Valid @RequestBody UserTestRecordCreateRequest request
+    ) {
+        return userTestRecordService.create(request);
+    }
+
+    @PatchMapping("/{testRecordId}/complete")
+    public UserTestRecordDetailResponse complete(
+            @Positive @PathVariable Long testRecordId
+    ) {
+        return userTestRecordService.complete(testRecordId);
+    }
+
+    @GetMapping("/me")
+    @ResponseStatus(HttpStatus.OK)
+    public List<UserTestRecordResponse> findAll() {
+        return userTestRecordService.findAll();
+    }
+
+    @GetMapping("/{testRecordId}")
+    @ResponseStatus(HttpStatus.OK)
+    public UserTestRecordDetailResponse findById(
+            @Positive @PathVariable Long testRecordId
+    ) {
+        return userTestRecordService.findById(testRecordId);
+    }
+
+    @DeleteMapping("/{testRecordId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(
+            @Positive @PathVariable Long testRecordId
+    ) {
+        userTestRecordService.delete(testRecordId);
+    }
+
+}

--- a/src/main/java/com/dnd5/timoapi/domain/user/presentation/request/UserServiceFeedbackCreateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/presentation/request/UserServiceFeedbackCreateRequest.java
@@ -1,0 +1,15 @@
+package com.dnd5.timoapi.domain.user.presentation.request;
+
+import com.dnd5.timoapi.domain.user.domain.model.UserTestRecord;
+import com.dnd5.timoapi.domain.user.domain.model.enums.UserTestRecordStatus;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record UserTestRecordCreateRequest(
+        @Positive @NotNull
+        Long testId
+) {
+    public UserTestRecord toModel() {
+        return UserTestRecord.create(testId, UserTestRecordStatus.IN_PROGRESS);
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/user/presentation/request/UserServiceFeedbackCreateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/presentation/request/UserServiceFeedbackCreateRequest.java
@@ -1,15 +1,16 @@
 package com.dnd5.timoapi.domain.user.presentation.request;
 
-import com.dnd5.timoapi.domain.user.domain.model.UserTestRecord;
-import com.dnd5.timoapi.domain.user.domain.model.enums.UserTestRecordStatus;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
+import com.dnd5.timoapi.domain.user.domain.model.UserServiceFeedback;
+import jakarta.validation.constraints.*;
 
-public record UserTestRecordCreateRequest(
+public record UserServiceFeedbackCreateRequest(
         @Positive @NotNull
-        Long testId
+        @Min(value=0) @Max(value=5)
+        Long serviceRating,
+        @NotEmpty
+        String serviceFeedback
 ) {
-    public UserTestRecord toModel() {
-        return UserTestRecord.create(testId, UserTestRecordStatus.IN_PROGRESS);
+    public UserServiceFeedback toModel() {
+        return UserServiceFeedback.create(serviceRating, serviceFeedback);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/user/presentation/request/UserServiceFeedbackCreateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/presentation/request/UserServiceFeedbackCreateRequest.java
@@ -4,13 +4,13 @@ import com.dnd5.timoapi.domain.user.domain.model.UserServiceFeedback;
 import jakarta.validation.constraints.*;
 
 public record UserServiceFeedbackCreateRequest(
-        @Positive @NotNull
+        @NotNull
         @Min(value=0) @Max(value=5)
         Long serviceRating,
         @NotEmpty
         String serviceFeedback
 ) {
-    public UserServiceFeedback toModel() {
-        return UserServiceFeedback.create(serviceRating, serviceFeedback);
+    public UserServiceFeedback toModel(Long userId) {
+        return UserServiceFeedback.create(userId, serviceRating, serviceFeedback);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/user/presentation/response/UserServiceFeedbackDetailResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/presentation/response/UserServiceFeedbackDetailResponse.java
@@ -1,0 +1,19 @@
+package com.dnd5.timoapi.domain.user.presentation.response;
+
+import com.dnd5.timoapi.domain.user.domain.model.UserServiceFeedback;
+
+public record UserServiceFeedbackResponse(
+        Long id,
+        Long userId,
+        Long serviceRating,
+        String serviceFeedback
+) {
+    public static UserServiceFeedbackResponse from(UserServiceFeedback model) {
+        return new UserServiceFeedbackResponse(
+                model.id(),
+                model.userId(),
+                model.serviceRating(),
+                model.serviceFeedback()
+        );
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/user/presentation/response/UserServiceFeedbackDetailResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/presentation/response/UserServiceFeedbackDetailResponse.java
@@ -1,19 +1,27 @@
 package com.dnd5.timoapi.domain.user.presentation.response;
 
+import com.dnd5.timoapi.domain.test.presentation.response.TestResultResponse;
 import com.dnd5.timoapi.domain.user.domain.model.UserServiceFeedback;
+import com.dnd5.timoapi.domain.user.domain.model.UserTestRecord;
 
-public record UserServiceFeedbackResponse(
+import java.time.LocalDateTime;
+
+public record UserServiceFeedbackDetailResponse(
         Long id,
         Long userId,
         Long serviceRating,
-        String serviceFeedback
+        String serviceFeedback,
+        LocalDateTime createdAt
 ) {
-    public static UserServiceFeedbackResponse from(UserServiceFeedback model) {
-        return new UserServiceFeedbackResponse(
+    public static UserServiceFeedbackDetailResponse of(
+            UserServiceFeedback model
+    ) {
+        return new UserServiceFeedbackDetailResponse(
                 model.id(),
                 model.userId(),
                 model.serviceRating(),
-                model.serviceFeedback()
+                model.serviceFeedback(),
+                model.createdAt()
         );
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/user/presentation/response/UserServiceFeedbackResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/presentation/response/UserServiceFeedbackResponse.java
@@ -1,21 +1,19 @@
 package com.dnd5.timoapi.domain.user.presentation.response;
 
-import com.dnd5.timoapi.domain.user.domain.model.UserTestRecord;
-import com.dnd5.timoapi.domain.user.domain.model.enums.UserTestRecordStatus;
-import java.time.LocalDateTime;
+import com.dnd5.timoapi.domain.user.domain.model.UserServiceFeedback;
 
-public record UserTestRecordResponse(
+public record UserServiceFeedbackResponse(
         Long id,
-        Long testId,
-        UserTestRecordStatus status,
-        LocalDateTime createdAt
+        Long userId,
+        Long serviceRating,
+        String serviceFeedback
 ) {
-    public static UserTestRecordResponse from(UserTestRecord model) {
-        return new UserTestRecordResponse(
+    public static UserServiceFeedbackResponse from(UserServiceFeedback model) {
+        return new UserServiceFeedbackResponse(
                 model.id(),
-                model.testId(),
-                model.status(),
-                model.createdAt()
+                model.userId(),
+                model.serviceRating(),
+                model.serviceFeedback()
         );
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/user/presentation/response/UserServiceFeedbackResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/presentation/response/UserServiceFeedbackResponse.java
@@ -1,0 +1,21 @@
+package com.dnd5.timoapi.domain.user.presentation.response;
+
+import com.dnd5.timoapi.domain.user.domain.model.UserTestRecord;
+import com.dnd5.timoapi.domain.user.domain.model.enums.UserTestRecordStatus;
+import java.time.LocalDateTime;
+
+public record UserTestRecordResponse(
+        Long id,
+        Long testId,
+        UserTestRecordStatus status,
+        LocalDateTime createdAt
+) {
+    public static UserTestRecordResponse from(UserTestRecord model) {
+        return new UserTestRecordResponse(
+                model.id(),
+                model.testId(),
+                model.status(),
+                model.createdAt()
+        );
+    }
+}


### PR DESCRIPTION
## What is this PR? :mag:
-  사용자가 서비스 피드백(별점 + 텍스트)을 등록
-  어드민이 이를 조회/삭제할 수 있는 API를 추가

## Changes :memo:
  | 메서드 | 경로 | 설명 | 권한 |
  |--------|------|------|------|
  | `POST` | `/service-feedbacks` | 피드백 등록 | 유저 |
  | `GET` | `/admin/service-feedbacks` | 전체 조회 | 어드민 |
  | `GET` | `/admin/service-feedbacks/{id}` | 단건 조회 | 어드민 |
  | `DELETE` | `/admin/service-feedbacks/{id}` | 삭제 | 어드민 |

  - 유저당 피드백 1개 제한 (중복 등록 시 409 반환)
  - `serviceRating` 0~5 범위 유효성 검증

---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now submit service feedback with a rating (0–5 scale) and detailed comments.
  * Admin interface added to view, retrieve details, and manage all service feedback submissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnd-side-project/dnd-14th-5-backend/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->