### PR TITLE
refactor/migrate-vertex-ai-to-google-ai

### DIFF
--- a/src/main/java/com/dnd5/timoapi/global/infrastructure/gemini/GeminiClient.java
+++ b/src/main/java/com/dnd5/timoapi/global/infrastructure/gemini/GeminiClient.java
@@ -7,8 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.util.List;
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -23,33 +21,36 @@ public class GeminiClient {
 
         GeminiRequest request = GeminiRequest.of(systemPrompt, userPrompt);
 
-        List<GeminiResponse> responses;
+        GeminiResponse response;
         try {
-            responses = geminiWebClient.post()
-                    .uri("/publishers/google/models/{model}:streamGenerateContent?key={apiKey}",
+            response = geminiWebClient.post()
+                    .uri("/models/{model}:generateContent?key={apiKey}",
                             properties.model(), properties.apiKey())
                     .bodyValue(request)
                     .retrieve()
-                    .bodyToFlux(GeminiResponse.class)
-                    .collectList()
+                    .bodyToMono(GeminiResponse.class)
                     .block();
+
         } catch (Exception e) {
             log.error("gemini_request_failed reason=exception latencyMs={}", System.currentTimeMillis() - startMs, e);
             throw e;
         }
 
-        if (responses == null || responses.isEmpty()) {
+        if (response == null) {
             log.error("gemini_request_failed reason=empty_response latencyMs={}", System.currentTimeMillis() - startMs);
             throw new RuntimeException("Gemini API response is empty");
         }
 
         StringBuilder result = new StringBuilder();
-        for (GeminiResponse response : responses) {
-            if (response.candidates() != null && !response.candidates().isEmpty()) {
-                var parts = response.candidates().get(0).content().parts();
-                if (parts != null && !parts.isEmpty()) {
-                    result.append(parts.get(0).text());
-                }
+        if (response.candidates() != null
+                && !response.candidates().isEmpty()) {
+
+            var parts = response.candidates().get(0)
+                    .content()
+                    .parts();
+
+            if (parts != null && !parts.isEmpty()) {
+                result.append(parts.get(0).text());
             }
         }
 

--- a/src/main/java/com/dnd5/timoapi/global/infrastructure/gemini/dto/GeminiRequest.java
+++ b/src/main/java/com/dnd5/timoapi/global/infrastructure/gemini/dto/GeminiRequest.java
@@ -5,16 +5,32 @@ import java.util.List;
 
 public record GeminiRequest(
         @JsonProperty("system_instruction") SystemInstruction systemInstruction,
-        List<Content> contents
+        List<Content> contents,
+        @JsonProperty("generationConfig") GenerationConfig generationConfig
 ) {
     public static GeminiRequest of(String systemPrompt, String userPrompt) {
         SystemInstruction systemInstruction = new SystemInstruction(List.of(new Part(systemPrompt)));
         Content userContent = new Content("user", List.of(new Part(userPrompt)));
+        GenerationConfig config = new GenerationConfig(
+                0.7,
+                "application/json",
+                new ThinkingConfig(0)
+        );
 
-        return new GeminiRequest(systemInstruction, List.of(userContent));
+        return new GeminiRequest(systemInstruction, List.of(userContent), config);
     }
 
     public record SystemInstruction(List<Part> parts) {}
     public record Content(String role, List<Part> parts) {}
     public record Part(String text) {}
+
+    public record GenerationConfig(
+            double temperature,
+            @JsonProperty("responseMimeType") String responseMimeType,
+            @JsonProperty("thinkingConfig") ThinkingConfig thinkingConfig
+    ) {}
+
+    public record ThinkingConfig(
+            @JsonProperty("thinkingBudget") int thinkingBudget
+    ) {}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,7 +70,7 @@ spring:
 
 logging:
   level:
-    org.hibernate.SQL: debug
+    org.hibernate.SQL: error
     org.hibernate.orm.jdbc.bind: trace
   api:
     max-body-size: 65536
@@ -78,7 +78,7 @@ logging:
 gemini:
   api-key: ${GEMINI_API_KEY}
   model: ${GEMINI_MODEL}
-  base-url: https://aiplatform.googleapis.com/v1
+  base-url: https://generativelanguage.googleapis.com/v1beta
 
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS}


### PR DESCRIPTION
## What is this PR? :mag:
- GCP 서버 -> 홈서버(우분투) 이전에 따른 AI 플랫폼 마이그레이션
- Gemini AI 피드백 플랫폼을 GCP 연동 Vertex AI에서 Google AI Studio로 마이그레이션합니다.

## Changes :memo:
- Gemini API 엔드포인트를 Google AI Studio(generativelanguage.googleapis.com/v1beta)로 변경
- 위에 따라 스트리밍 방식(streamGenerateContent) 대신 단일 응답 방식(generateContent)으로 전환
- generationConfig 추가: JSON 포맷 강제, temperature 0.7로 출력 일관성 향상, thinking 비활성화로 응답 속도 개선 (~15초 → ~8초)

---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated AI content generation to use a more reliable, non-streaming API method with enhanced error handling.
  * Configured AI generation parameters to optimize response quality and format consistency.

* **Configuration**
  * Updated AI service endpoint URL.
  * Adjusted database operation logging levels to reduce verbosity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->