### PR TITLE
feat/image-upload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,14 @@
 # 프로젝트 규칙
 
 - 커밋 메시지는 한글로 작성
+
+## 논의 필요: 캐릭터 그룹 참여 로직
+
+현재 `getTodayReflectionsForCharacterGroup`은 멤버 여부 무관하게 해당 category의 모든 회고를 보여줌.
+
+의도된 스펙:
+- 캐릭터 그룹은 모든 유저에게 노출 (`getMyGroups` 현재 구현 OK)
+- 단, 내 회고가 해당 그룹에 등록되려면 `joinGroup` 해야 함
+- 즉 `getTodayReflectionsForCharacterGroup`은 groupMember인 유저의 회고만 반환해야 함
+
+→ 팀원과 스펙 확정 후 수정 필요

--- a/src/main/java/com/dnd5/timoapi/TimoBackendApiApplication.java
+++ b/src/main/java/com/dnd5/timoapi/TimoBackendApiApplication.java
@@ -1,12 +1,15 @@
 package com.dnd5.timoapi;
 
+import com.dnd5.timoapi.global.infrastructure.file.FileStorageProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @EnableScheduling
+@EnableConfigurationProperties(FileStorageProperties.class)
 @SpringBootApplication
 public class TimoBackendApiApplication {
 

--- a/src/main/java/com/dnd5/timoapi/global/infrastructure/file/FileStorageProperties.java
+++ b/src/main/java/com/dnd5/timoapi/global/infrastructure/file/FileStorageProperties.java
@@ -1,0 +1,7 @@
+package com.dnd5.timoapi.global.infrastructure.file;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.upload")
+public record FileStorageProperties(String dir, String baseUrl) {
+}

--- a/src/main/java/com/dnd5/timoapi/global/infrastructure/file/FileStorageService.java
+++ b/src/main/java/com/dnd5/timoapi/global/infrastructure/file/FileStorageService.java
@@ -1,0 +1,45 @@
+package com.dnd5.timoapi.global.infrastructure.file;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+@Service
+public class FileStorageService {
+
+    private final Path uploadDir;
+    private final String baseUrl;
+
+    public FileStorageService(FileStorageProperties properties) {
+        this.uploadDir = Paths.get(properties.dir()).toAbsolutePath().normalize();
+        this.baseUrl = properties.baseUrl();
+        try {
+            Files.createDirectories(this.uploadDir);
+        } catch (IOException e) {
+            throw new UncheckedIOException("업로드 디렉토리 생성 실패: " + this.uploadDir, e);
+        }
+    }
+
+    public String store(MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        String extension = (originalFilename != null && originalFilename.contains("."))
+                ? originalFilename.substring(originalFilename.lastIndexOf("."))
+                : "";
+        String filename = UUID.randomUUID().toString().replace("-", "") + extension;
+
+        try {
+            Path target = uploadDir.resolve(filename);
+            file.transferTo(target);
+        } catch (IOException e) {
+            throw new UncheckedIOException("파일 저장 실패", e);
+        }
+
+        return baseUrl + "/uploads/" + filename;
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/global/infrastructure/file/FileWebMvcConfig.java
+++ b/src/main/java/com/dnd5/timoapi/global/infrastructure/file/FileWebMvcConfig.java
@@ -1,0 +1,24 @@
+package com.dnd5.timoapi.global.infrastructure.file;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.file.Paths;
+
+@Configuration
+public class FileWebMvcConfig implements WebMvcConfigurer {
+
+    private final FileStorageProperties properties;
+
+    public FileWebMvcConfig(FileStorageProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        String absolutePath = Paths.get(properties.dir()).toAbsolutePath().normalize().toUri().toString();
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations(absolutePath);
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/global/presentation/ImageController.java
+++ b/src/main/java/com/dnd5/timoapi/global/presentation/ImageController.java
@@ -1,0 +1,27 @@
+package com.dnd5.timoapi.global.presentation;
+
+import com.dnd5.timoapi.global.infrastructure.file.FileStorageService;
+import com.dnd5.timoapi.global.presentation.response.ImageUploadResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/images")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final FileStorageService fileStorageService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ImageUploadResponse upload(@RequestParam("file") MultipartFile file) {
+        String url = fileStorageService.store(file);
+        return new ImageUploadResponse(url);
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/global/presentation/response/ImageUploadResponse.java
+++ b/src/main/java/com/dnd5/timoapi/global/presentation/response/ImageUploadResponse.java
@@ -1,0 +1,4 @@
+package com.dnd5.timoapi.global.presentation.response;
+
+public record ImageUploadResponse(String url) {
+}

--- a/src/main/java/com/dnd5/timoapi/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/dnd5/timoapi/global/security/config/SecurityConfig.java
@@ -96,10 +96,13 @@ public class SecurityConfig {
                         // 그룹
                         .requestMatchers("/groups/**").authenticated()
 
+                        // 이미지 업로드
+                        .requestMatchers(HttpMethod.POST, "/images").authenticated()
+
                         // 테스트 (유저)
                         .requestMatchers(HttpMethod.GET, "/tests").authenticated()
                         .requestMatchers(HttpMethod.GET, "/tests/*/questions").authenticated()
-                        
+
                         .anyRequest().permitAll()
                 )
                 .oauth2Login(oauth -> oauth

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -128,3 +128,8 @@ cookie:
   same-site: ${COOKIE_SAME_SITE:None}
   domain: ${COOKIE_DOMAIN:}
   path: ${COOKIE_PATH:/}
+
+app:
+  upload:
+    dir: ${UPLOAD_DIR:/home/server/uploads}
+    base-url: ${UPLOAD_BASE_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -105,3 +105,8 @@ notification:
 fcm:
   enabled: ${FCM_ENABLED:false}
   credentials-path: ${FCM_CREDENTIALS_PATH:}
+
+app:
+  upload:
+    dir: ${UPLOAD_DIR:./uploads}
+    base-url: ${UPLOAD_BASE_URL:http://localhost:8080}


### PR DESCRIPTION
## What is this PR? :mag:
이미지 업로드 API 추가 (로컬 파일시스템)

## Changes :memo:
이미지 업로드 API 및 기타 설정


---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Authenticated users can now upload images via a new endpoint. Uploaded files are securely stored locally and served through a configurable URL, enabling flexible deployment across different server environments. Storage directory and retrieval URL settings can be customized independently for each deployment, with support for content delivery network integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->