### PR TITLE
feat/character-group-reflection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,9 @@
 
 - 커밋 메시지는 한글로 작성
 
-## 논의 필요: 캐릭터 그룹 참여 로직
+## 캐릭터 그룹 참여 로직
 
-현재 `getTodayReflectionsForCharacterGroup`은 멤버 여부 무관하게 해당 category의 모든 회고를 보여줌.
-
-의도된 스펙:
-- 캐릭터 그룹은 모든 유저에게 노출 (`getMyGroups` 현재 구현 OK)
-- 단, 내 회고가 해당 그룹에 등록되려면 `joinGroup` 해야 함
-- 즉 `getTodayReflectionsForCharacterGroup`은 groupMember인 유저의 회고만 반환해야 함
-
-→ 팀원과 스펙 확정 후 수정 필요
+- 캐릭터 그룹은 모든 유저에게 노출 (`getMyGroups` OK)
+- `joinGroup` 이후부터 내 회고가 그룹에 등록(노출)됨
+- `leaveGroup` 시 멤버십 제거 → 그룹 뷰에서 자동 숨김 (회고 데이터 삭제 없음)
+- `getTodayReflectionsForCharacterGroup`은 groupMember인 유저의 회고만 반환 (구현 완료)

--- a/src/main/java/com/dnd5/timoapi/domain/group/application/service/AdminGroupService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/application/service/AdminGroupService.java
@@ -1,0 +1,72 @@
+package com.dnd5.timoapi.domain.group.application.service;
+
+import com.dnd5.timoapi.domain.group.domain.entity.GroupEntity;
+import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberEntity;
+import com.dnd5.timoapi.domain.group.domain.model.Group;
+import com.dnd5.timoapi.domain.group.domain.model.GroupMember;
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupMemberRole;
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberRepository;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupRepository;
+import com.dnd5.timoapi.domain.group.exception.GroupErrorCode;
+import com.dnd5.timoapi.domain.group.presentation.request.GroupCreateRequest;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupCreateResponse;
+import com.dnd5.timoapi.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminGroupService {
+
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+
+    public GroupCreateResponse createGroup(GroupCreateRequest request) {
+        String code = generateUniqueCode();
+        Group group = Group.create(code, request.name(), request.type(), request.image(), null);
+        GroupEntity savedGroup = groupRepository.save(GroupEntity.from(group));
+        return GroupCreateResponse.from(savedGroup.toModel());
+    }
+
+    public void seedDummyGroups() {
+        List<Long> userIds = List.of(1L, 2L, 3L, 4L, 5L);
+
+        for (int i = 1; i <= 10; i++) {
+            String code = generateUniqueCode();
+            Group group = Group.create(code, "테스트 그룹 " + i, GroupType.FRIEND, null, null);
+            GroupEntity savedGroup = groupRepository.save(GroupEntity.from(group));
+
+            for (int j = 0; j < userIds.size(); j++) {
+                GroupMemberRole role = (j == 0) ? GroupMemberRole.OWNER : GroupMemberRole.MEMBER;
+                groupMemberRepository.save(GroupMemberEntity.from(
+                        GroupMember.create(savedGroup.getId(), userIds.get(j), role)
+                ));
+            }
+        }
+    }
+
+    public void deleteGroup(Long groupId) {
+        GroupEntity groupEntity = getGroupEntity(groupId);
+        groupMemberRepository.findAllByGroupIdAndDeletedAtIsNull(groupId).forEach(GroupMemberEntity::softDelete);
+        groupEntity.softDelete();
+    }
+
+    private GroupEntity getGroupEntity(Long groupId) {
+        return groupRepository.findByIdAndDeletedAtIsNull(groupId)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.GROUP_NOT_FOUND));
+    }
+
+    private String generateUniqueCode() {
+        String code;
+        do {
+            code = UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase();
+        } while (groupRepository.existsByCodeAndDeletedAtIsNull(code));
+        return code;
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupService.java
@@ -61,6 +61,22 @@ public class GroupService {
     }
 
     @Transactional(readOnly = true)
+    public GroupResponse getGroupByCode(String code) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        GroupEntity groupEntity = groupRepository.findByCodeAndDeletedAtIsNull(code)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.GROUP_NOT_FOUND));
+
+        Long groupId = groupEntity.getId();
+        GroupMemberRole myRole = groupMemberRepository
+                .findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)
+                .map(GroupMemberEntity::getRole)
+                .orElse(null);
+
+        int memberCount = (int) groupMemberRepository.countByGroupIdAndDeletedAtIsNull(groupId);
+        return GroupResponse.of(groupEntity.toModel(), memberCount, myRole);
+    }
+
+    @Transactional(readOnly = true)
     public List<GroupResponse> getMyGroups() {
         Long userId = SecurityUtil.getCurrentUserId();
         List<GroupMemberEntity> myMemberships = groupMemberRepository.findAllByUserIdAndDeletedAtIsNull(userId);

--- a/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupService.java
@@ -32,6 +32,7 @@ import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -63,13 +64,25 @@ public class GroupService {
     public List<GroupResponse> getMyGroups() {
         Long userId = SecurityUtil.getCurrentUserId();
         List<GroupMemberEntity> myMemberships = groupMemberRepository.findAllByUserIdAndDeletedAtIsNull(userId);
-        return myMemberships.stream()
+        Set<Long> myGroupIds = myMemberships.stream().map(GroupMemberEntity::getGroupId).collect(Collectors.toSet());
+
+        List<GroupResponse> myGroups = myMemberships.stream()
                 .map(member -> {
                     GroupEntity groupEntity = getGroupEntity(member.getGroupId());
                     int memberCount = (int) groupMemberRepository.countByGroupIdAndDeletedAtIsNull(groupEntity.getId());
                     return GroupResponse.of(groupEntity.toModel(), memberCount, member.getRole());
                 })
-                .toList();
+                .collect(Collectors.toList());
+
+        groupRepository.findAllByTypeAndDeletedAtIsNull(GroupType.CHARACTER).stream()
+                .filter(g -> !myGroupIds.contains(g.getId()))
+                .map(g -> {
+                    int memberCount = (int) groupMemberRepository.countByGroupIdAndDeletedAtIsNull(g.getId());
+                    return GroupResponse.of(g.toModel(), memberCount, null);
+                })
+                .forEach(myGroups::add);
+
+        return myGroups;
     }
 
     @Transactional(readOnly = true)
@@ -163,43 +176,58 @@ public class GroupService {
 
     private List<GroupTodayReflectionItem> getTodayReflectionsForCharacterGroup(
             GroupEntity groupEntity, LocalDate today, GroupReflectionSort sort) {
-        List<ReflectionEntity> reflections = reflectionRepository.findAllByDateAndQuestionCategory(today, groupEntity.getCategory());
-        if (reflections.isEmpty()) {
+        List<Long> memberUserIds = groupMemberRepository.findAllByGroupIdAndDeletedAtIsNull(groupEntity.getId())
+                .stream().map(GroupMemberEntity::getUserId).toList();
+
+        if (memberUserIds.isEmpty()) {
             return List.of();
         }
 
-        List<Long> questionIds = reflections.stream().map(ReflectionEntity::getQuestionId).distinct().toList();
-        List<Long> userIds = reflections.stream().map(ReflectionEntity::getUserId).distinct().toList();
-
-        Map<Long, ReflectionQuestionEntity> questionMap = reflectionQuestionRepository.findAllById(questionIds)
-                .stream().collect(Collectors.toMap(ReflectionQuestionEntity::getId, q -> q));
-        Map<Long, UserEntity> userMap = userRepository.findAllById(userIds)
+        Map<Long, UserEntity> userMap = userRepository.findAllById(memberUserIds)
                 .stream().collect(Collectors.toMap(UserEntity::getId, u -> u));
 
-        Comparator<ReflectionEntity> comparator = switch (sort) {
-            case STREAK -> Comparator.comparingInt((ReflectionEntity r) -> {
-                UserEntity u = userMap.get(r.getUserId());
+        Map<Long, ReflectionEntity> reflectionByUserId = reflectionRepository
+                .findAllByDateAndUserIdIn(today, memberUserIds)
+                .stream().collect(Collectors.toMap(ReflectionEntity::getUserId, r -> r));
+
+        List<Long> questionIds = reflectionByUserId.values().stream()
+                .map(ReflectionEntity::getQuestionId).distinct().toList();
+        Map<Long, ReflectionQuestionEntity> questionMap = questionIds.isEmpty() ? Map.of() :
+                reflectionQuestionRepository.findAllById(questionIds)
+                        .stream().collect(Collectors.toMap(ReflectionQuestionEntity::getId, q -> q));
+
+        Comparator<Long> comparator = switch (sort) {
+            case STREAK -> Comparator.comparingInt((Long uid) -> {
+                UserEntity u = userMap.get(uid);
                 return u != null ? u.getStreakDays() : 0;
             }).reversed();
-            case TOTAL -> Comparator.comparingInt((ReflectionEntity r) -> {
-                UserEntity u = userMap.get(r.getUserId());
+            case TOTAL -> Comparator.comparingInt((Long uid) -> {
+                UserEntity u = userMap.get(uid);
                 return u != null ? u.getTotalDays() : 0;
             }).reversed();
-            default -> Comparator.comparing(ReflectionEntity::getCreatedAt, Comparator.reverseOrder());
+            default -> (a, b) -> {
+                ReflectionEntity ra = reflectionByUserId.get(a);
+                ReflectionEntity rb = reflectionByUserId.get(b);
+                if (ra == null && rb == null) return 0;
+                if (ra == null) return 1;
+                if (rb == null) return -1;
+                return rb.getCreatedAt().compareTo(ra.getCreatedAt());
+            };
         };
 
-        return reflections.stream()
+        return memberUserIds.stream()
                 .sorted(comparator)
-                .map(r -> {
-                    ReflectionQuestionEntity question = questionMap.get(r.getQuestionId());
-                    UserEntity user = userMap.get(r.getUserId());
+                .map(uid -> {
+                    UserEntity user = userMap.get(uid);
+                    ReflectionEntity reflection = reflectionByUserId.get(uid);
+                    ReflectionQuestionEntity question = reflection != null ? questionMap.get(reflection.getQuestionId()) : null;
                     return new GroupTodayReflectionItem(
-                            r.getUserId(),
+                            uid,
                             user != null ? user.getNickname() : null,
                             user != null ? user.getCategory() : null,
                             question != null ? question.getContent() : null,
                             question != null ? question.getCategory() : null,
-                            r.getAnswerText(),
+                            reflection != null ? reflection.getAnswerText() : null,
                             user != null ? user.getStreakDays() : 0,
                             user != null ? user.getTotalDays() : 0
                     );
@@ -271,30 +299,6 @@ public class GroupService {
                     );
                 })
                 .toList();
-    }
-
-    public GroupCreateResponse adminCreateGroup(GroupCreateRequest request) {
-        String code = generateUniqueCode();
-        Group group = Group.create(code, request.name(), request.type(), request.image(), null);
-        GroupEntity savedGroup = groupRepository.save(GroupEntity.from(group));
-        return GroupCreateResponse.from(savedGroup.toModel());
-    }
-
-    public void seedDummyGroups() {
-        List<Long> userIds = List.of(1L, 2L, 3L, 4L, 5L);
-
-        for (int i = 1; i <= 10; i++) {
-            String code = generateUniqueCode();
-            Group group = Group.create(code, "테스트 그룹 " + i, GroupType.FRIEND, null, null);
-            GroupEntity savedGroup = groupRepository.save(GroupEntity.from(group));
-
-            for (int j = 0; j < userIds.size(); j++) {
-                GroupMemberRole role = (j == 0) ? GroupMemberRole.OWNER : GroupMemberRole.MEMBER;
-                groupMemberRepository.save(GroupMemberEntity.from(
-                        GroupMember.create(savedGroup.getId(), userIds.get(j), role)
-                ));
-            }
-        }
     }
 
     private void handleOwnerLeave(Long groupId, GroupMemberEntity ownerMember) {

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupRepository.java
@@ -12,6 +12,8 @@ public interface GroupRepository extends JpaRepository<GroupEntity, Long> {
 
     Optional<GroupEntity> findByIdAndDeletedAtIsNull(Long id);
 
+    Optional<GroupEntity> findByCodeAndDeletedAtIsNull(String code);
+
     boolean existsByCodeAndDeletedAtIsNull(String code);
 
     boolean existsByTypeAndCategoryAndDeletedAtIsNull(GroupType type, ZtpiCategory category);

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupRepository.java
@@ -5,6 +5,7 @@ import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
 import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<GroupEntity, Long> {
@@ -14,4 +15,6 @@ public interface GroupRepository extends JpaRepository<GroupEntity, Long> {
     boolean existsByCodeAndDeletedAtIsNull(String code);
 
     boolean existsByTypeAndCategoryAndDeletedAtIsNull(GroupType type, ZtpiCategory category);
+
+    List<GroupEntity> findAllByTypeAndDeletedAtIsNull(GroupType type);
 }

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/AdminGroupController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/AdminGroupController.java
@@ -1,12 +1,15 @@
 package com.dnd5.timoapi.domain.group.presentation;
 
-import com.dnd5.timoapi.domain.group.application.service.GroupService;
+import com.dnd5.timoapi.domain.group.application.service.AdminGroupService;
 import com.dnd5.timoapi.domain.group.presentation.request.GroupCreateRequest;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupCreateResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,17 +22,23 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public class AdminGroupController {
 
-    private final GroupService groupService;
+    private final AdminGroupService adminGroupService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public GroupCreateResponse create(@Valid @RequestBody GroupCreateRequest request) {
-        return groupService.adminCreateGroup(request);
+        return adminGroupService.createGroup(request);
     }
 
     @PostMapping("/seed")
     @ResponseStatus(HttpStatus.CREATED)
     public void seed() {
-        groupService.seedDummyGroups();
+        adminGroupService.seedDummyGroups();
+    }
+
+    @DeleteMapping("/{groupId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@Positive @PathVariable Long groupId) {
+        adminGroupService.deleteGroup(groupId);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/GroupController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/GroupController.java
@@ -32,7 +32,10 @@ public class GroupController {
     }
 
     @GetMapping
-    public List<GroupResponse> getMyGroups() {
+    public List<GroupResponse> getGroups(@RequestParam(required = false) String code) {
+        if (code != null) {
+            return List.of(groupService.getGroupByCode(code));
+        }
         return groupService.getMyGroups();
     }
 

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/domain/repository/ReflectionRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/domain/repository/ReflectionRepository.java
@@ -54,4 +54,5 @@ public interface ReflectionRepository extends JpaRepository<ReflectionEntity, Lo
     List<ReflectionEntity> findAllByDateAndUserIdIn(
             @Param("date") LocalDate date,
             @Param("userIds") List<Long> userIds);
+
 }

--- a/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupServiceTest.java
+++ b/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupServiceTest.java
@@ -104,7 +104,7 @@ class GroupServiceTest {
     }
 
     @Test
-    void getMyGroups_내_그룹만_반환() {
+    void getMyGroups_내_FRIEND_그룹_반환() {
         Long userId = 1L;
 
         GroupMemberEntity membership = mock(GroupMemberEntity.class);
@@ -120,6 +120,7 @@ class GroupServiceTest {
         when(groupMemberRepository.findAllByUserIdAndDeletedAtIsNull(userId)).thenReturn(List.of(membership));
         when(groupRepository.findByIdAndDeletedAtIsNull(10L)).thenReturn(Optional.of(groupEntity));
         when(groupMemberRepository.countByGroupIdAndDeletedAtIsNull(10L)).thenReturn(3L);
+        when(groupRepository.findAllByTypeAndDeletedAtIsNull(GroupType.CHARACTER)).thenReturn(List.of());
 
         try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
             mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
@@ -129,6 +130,31 @@ class GroupServiceTest {
             assertThat(result).hasSize(1);
             assertThat(result.get(0).memberCount()).isEqualTo(3);
             assertThat(result.get(0).myRole()).isEqualTo(GroupMemberRole.OWNER);
+        }
+    }
+
+    @Test
+    void getMyGroups_캐릭터그룹은_미멤버여도_포함() {
+        Long userId = 1L;
+
+        GroupEntity characterGroup = mock(GroupEntity.class);
+        when(characterGroup.getId()).thenReturn(20L);
+        when(characterGroup.toModel()).thenReturn(
+                new com.dnd5.timoapi.domain.group.domain.model.Group(20L, "CHAR1234", "그늘이", GroupType.CHARACTER, null, ZtpiCategory.PAST_NEGATIVE, null, null)
+        );
+
+        when(groupMemberRepository.findAllByUserIdAndDeletedAtIsNull(userId)).thenReturn(List.of());
+        when(groupRepository.findAllByTypeAndDeletedAtIsNull(GroupType.CHARACTER)).thenReturn(List.of(characterGroup));
+        when(groupMemberRepository.countByGroupIdAndDeletedAtIsNull(20L)).thenReturn(0L);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            List<GroupResponse> result = groupService.getMyGroups();
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).type()).isEqualTo(GroupType.CHARACTER);
+            assertThat(result.get(0).myRole()).isNull();
         }
     }
 
@@ -415,14 +441,18 @@ class GroupServiceTest {
     }
 
     @Test
-    void getTodayReflections_CHARACTER_전체_유저_회고_반환() {
+    void getTodayReflections_CHARACTER_멤버만_회고_반환() {
         Long userId = 1L;
         Long groupId = 10L;
 
         GroupEntity groupEntity = mock(GroupEntity.class);
+        when(groupEntity.getId()).thenReturn(groupId);
         when(groupEntity.getType()).thenReturn(GroupType.CHARACTER);
-        when(groupEntity.getCategory()).thenReturn(ZtpiCategory.FUTURE);
         when(groupRepository.findByIdAndDeletedAtIsNull(groupId)).thenReturn(Optional.of(groupEntity));
+
+        GroupMemberEntity member = mock(GroupMemberEntity.class);
+        when(member.getUserId()).thenReturn(2L);
+        when(groupMemberRepository.findAllByGroupIdAndDeletedAtIsNull(groupId)).thenReturn(List.of(member));
 
         ReflectionEntity reflection = mock(ReflectionEntity.class);
         when(reflection.getUserId()).thenReturn(2L);
@@ -440,7 +470,7 @@ class GroupServiceTest {
         when(user.getStreakDays()).thenReturn(5);
         when(user.getTotalDays()).thenReturn(30);
 
-        when(reflectionRepository.findAllByDateAndQuestionCategory(any(LocalDate.class), eq(ZtpiCategory.FUTURE)))
+        when(reflectionRepository.findAllByDateAndUserIdIn(any(LocalDate.class), anyList()))
                 .thenReturn(List.of(reflection));
         when(reflectionQuestionRepository.findAllById(anyList())).thenReturn(List.of(question));
         when(userRepository.findAllById(anyList())).thenReturn(List.of(user));
@@ -456,6 +486,63 @@ class GroupServiceTest {
             assertThat(result.get(0).answerText()).isEqualTo("회고 내용");
             assertThat(result.get(0).streakDays()).isEqualTo(5);
             assertThat(result.get(0).totalDays()).isEqualTo(30);
+        }
+    }
+
+    @Test
+    void getTodayReflections_CHARACTER_회고_안한_멤버도_포함() {
+        Long userId = 1L;
+        Long groupId = 10L;
+
+        GroupEntity groupEntity = mock(GroupEntity.class);
+        when(groupEntity.getId()).thenReturn(groupId);
+        when(groupEntity.getType()).thenReturn(GroupType.CHARACTER);
+        when(groupRepository.findByIdAndDeletedAtIsNull(groupId)).thenReturn(Optional.of(groupEntity));
+
+        GroupMemberEntity member1 = mock(GroupMemberEntity.class);
+        when(member1.getUserId()).thenReturn(2L);
+        GroupMemberEntity member2 = mock(GroupMemberEntity.class);
+        when(member2.getUserId()).thenReturn(3L);
+        when(groupMemberRepository.findAllByGroupIdAndDeletedAtIsNull(groupId)).thenReturn(List.of(member1, member2));
+
+        ReflectionEntity reflection = mock(ReflectionEntity.class);
+        when(reflection.getUserId()).thenReturn(2L);
+        when(reflection.getQuestionId()).thenReturn(100L);
+        when(reflection.getAnswerText()).thenReturn("회고 내용");
+
+        ReflectionQuestionEntity question = mock(ReflectionQuestionEntity.class);
+        when(question.getId()).thenReturn(100L);
+        when(question.getContent()).thenReturn("오늘의 질문");
+        when(question.getCategory()).thenReturn(ZtpiCategory.FUTURE);
+
+        UserEntity user1 = mock(UserEntity.class);
+        when(user1.getId()).thenReturn(2L);
+        when(user1.getNickname()).thenReturn("홍길동");
+        when(user1.getStreakDays()).thenReturn(5);
+        when(user1.getTotalDays()).thenReturn(30);
+
+        UserEntity user2 = mock(UserEntity.class);
+        when(user2.getId()).thenReturn(3L);
+        when(user2.getNickname()).thenReturn("김철수");
+        when(user2.getStreakDays()).thenReturn(2);
+        when(user2.getTotalDays()).thenReturn(10);
+
+        when(reflectionRepository.findAllByDateAndUserIdIn(any(LocalDate.class), anyList()))
+                .thenReturn(List.of(reflection));
+        when(reflectionQuestionRepository.findAllById(anyList())).thenReturn(List.of(question));
+        when(userRepository.findAllById(anyList())).thenReturn(List.of(user1, user2));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            List<GroupTodayReflectionItem> result = groupService.getTodayReflections(groupId, GroupReflectionSort.LATEST);
+
+            assertThat(result).hasSize(2);
+            GroupTodayReflectionItem withReflection = result.stream().filter(r -> r.userId().equals(2L)).findFirst().orElseThrow();
+            GroupTodayReflectionItem withoutReflection = result.stream().filter(r -> r.userId().equals(3L)).findFirst().orElseThrow();
+            assertThat(withReflection.answerText()).isEqualTo("회고 내용");
+            assertThat(withoutReflection.answerText()).isNull();
+            assertThat(withoutReflection.questionContent()).isNull();
         }
     }
 }


### PR DESCRIPTION
## What is this PR? :mag:
캐릭터 그룹 회고 조회 스펙 수정 및 Admin 그룹 서비스 분리


##  Changes :memo:
- getTodayReflectionsForCharacterGroup: question.category 기준 필터 → 멤버 userId 기준 필터로 변경
- 유저 캐릭터(user.category)가 그룹 카테고리와 같으면, 질문 카테고리 무관하게 해당 유저의 모든 회고가 그룹에 등록됨
- joinGroup 이후부터만 노출, leaveGroup 시 자동 숨김 (데이터 삭제 없음)
- AdminGroupService 신규 생성: createGroup, seedDummyGroups, deleteGroup
- AdminGroupController: AdminGroupService 사용으로 변경, 어드민 그룹 삭제 API 추가 (DELETE /admin/groups/{groupId})
- GroupRepository: findAllByTypeAndDeletedAtIsNull 추가
- GroupServiceTest: 캐릭터 그룹 테스트 스펙 업데이트 + 회고 없는 멤버 포함 검증 추가

---
## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?                                                                                                                                                                      
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View all character groups (shows non-member groups with member counts).
  * Admin endpoints for creating, seeding, and deleting groups; lookup groups by code.

* **Bug Fixes**
  * Character-group reflections now return only group members' reflections and include members without reflections.

* **Documentation**
  * Clarified group participation, join/leave behavior, and visibility rules.

* **Tests**
  * Updated group/reflection tests to match new membership-based behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->