### PR TITLE
feat/character-group-reflection

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupService.java
@@ -168,7 +168,7 @@ public class GroupService {
         }
         groupMemberRepository.findByGroupIdAndUserId(groupId, userId)
                 .ifPresentOrElse(
-                        GroupMemberEntity::restore,
+                        GroupMemberEntity::restoreAsMember,
                         () -> groupMemberRepository.save(
                                 GroupMemberEntity.from(GroupMember.create(groupId, userId, GroupMemberRole.MEMBER))
                         )
@@ -191,7 +191,7 @@ public class GroupService {
         }
         groupMemberRepository.findByGroupIdAndUserId(groupId, userId)
                 .ifPresentOrElse(
-                        GroupMemberEntity::restore,
+                        GroupMemberEntity::restoreAsMember,
                         () -> groupMemberRepository.save(
                                 GroupMemberEntity.from(GroupMember.create(groupId, userId, GroupMemberRole.MEMBER))
                         )

--- a/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupService.java
@@ -20,6 +20,7 @@ import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionQuestionEntity;
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionQuestionRepository;
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
 import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
 import com.dnd5.timoapi.global.exception.BusinessException;
@@ -133,34 +134,64 @@ public class GroupService {
 
     public void updateGroup(Long groupId, GroupUpdateRequest request) {
         Long userId = SecurityUtil.getCurrentUserId();
+        GroupEntity groupEntity = getGroupEntity(groupId);
+        if (groupEntity.getType() == GroupType.CHARACTER) {
+            throw new BusinessException(GroupErrorCode.GROUP_CHARACTER_IMMUTABLE);
+        }
         GroupMemberEntity member = getGroupMember(groupId, userId);
         assertOwner(member);
-        GroupEntity groupEntity = getGroupEntity(groupId);
         groupEntity.update(request.name(), request.image());
     }
 
     public void deleteGroup(Long groupId) {
         Long userId = SecurityUtil.getCurrentUserId();
+        GroupEntity groupEntity = getGroupEntity(groupId);
+        if (groupEntity.getType() == GroupType.CHARACTER) {
+            throw new BusinessException(GroupErrorCode.GROUP_CHARACTER_IMMUTABLE);
+        }
         GroupMemberEntity member = getGroupMember(groupId, userId);
         assertOwner(member);
-        GroupEntity groupEntity = getGroupEntity(groupId);
         groupMemberRepository.findAllByGroupIdAndDeletedAtIsNull(groupId).forEach(GroupMemberEntity::softDelete);
         groupEntity.softDelete();
     }
 
-    public void joinGroup(Long groupId) {
+    public void joinGroupByCode(String code) {
         Long userId = SecurityUtil.getCurrentUserId();
-        getGroupEntity(groupId);
-
+        GroupEntity groupEntity = groupRepository.findByCodeAndDeletedAtIsNull(code)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.GROUP_NOT_FOUND));
+        if (groupEntity.getType() == GroupType.CHARACTER) {
+            throw new BusinessException(GroupErrorCode.GROUP_INVALID_CATEGORY);
+        }
+        Long groupId = groupEntity.getId();
         if (groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)) {
             throw new BusinessException(GroupErrorCode.GROUP_ALREADY_JOINED);
         }
-
         groupMemberRepository.findByGroupIdAndUserId(groupId, userId)
                 .ifPresentOrElse(
-                        existing -> {
-                            existing.restore();
-                        },
+                        GroupMemberEntity::restore,
+                        () -> groupMemberRepository.save(
+                                GroupMemberEntity.from(GroupMember.create(groupId, userId, GroupMemberRole.MEMBER))
+                        )
+                );
+    }
+
+    public void joinCharacterGroup() {
+        Long userId = SecurityUtil.getCurrentUserId();
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.GROUP_MEMBER_NOT_FOUND));
+        ZtpiCategory category = user.getCategory();
+        if (category == null) {
+            throw new BusinessException(GroupErrorCode.GROUP_CATEGORY_NOT_SET);
+        }
+        GroupEntity groupEntity = groupRepository.findByTypeAndCategoryAndDeletedAtIsNull(GroupType.CHARACTER, category)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.GROUP_NOT_FOUND));
+        Long groupId = groupEntity.getId();
+        if (groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)) {
+            throw new BusinessException(GroupErrorCode.GROUP_ALREADY_JOINED);
+        }
+        groupMemberRepository.findByGroupIdAndUserId(groupId, userId)
+                .ifPresentOrElse(
+                        GroupMemberEntity::restore,
                         () -> groupMemberRepository.save(
                                 GroupMemberEntity.from(GroupMember.create(groupId, userId, GroupMemberRole.MEMBER))
                         )
@@ -253,14 +284,14 @@ public class GroupService {
 
     private List<GroupTodayReflectionItem> getTodayReflectionsForFriendGroup(
             Long groupId, Long userId, LocalDate today, GroupReflectionSort sort) {
+        if (!groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)) {
+            throw new BusinessException(GroupErrorCode.GROUP_ACCESS_DENIED);
+        }
+
         List<Long> memberUserIds = groupMemberRepository.findAllByGroupIdAndDeletedAtIsNull(groupId)
                 .stream()
                 .map(GroupMemberEntity::getUserId)
                 .toList();
-
-        if (!groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)) {
-            throw new BusinessException(GroupErrorCode.GROUP_ACCESS_DENIED);
-        }
 
         if (memberUserIds.isEmpty()) {
             return List.of();

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/entity/GroupMemberEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/entity/GroupMemberEntity.java
@@ -45,4 +45,9 @@ public class GroupMemberEntity extends BaseEntity {
     public void promoteToOwner() {
         this.role = GroupMemberRole.OWNER;
     }
+
+    public void restoreAsMember() {
+        this.role = GroupMemberRole.MEMBER;
+        restore();
+    }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupRepository.java
@@ -14,6 +14,8 @@ public interface GroupRepository extends JpaRepository<GroupEntity, Long> {
 
     Optional<GroupEntity> findByCodeAndDeletedAtIsNull(String code);
 
+    Optional<GroupEntity> findByTypeAndCategoryAndDeletedAtIsNull(GroupType type, ZtpiCategory category);
+
     boolean existsByCodeAndDeletedAtIsNull(String code);
 
     boolean existsByTypeAndCategoryAndDeletedAtIsNull(GroupType type, ZtpiCategory category);

--- a/src/main/java/com/dnd5/timoapi/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/exception/GroupErrorCode.java
@@ -15,6 +15,9 @@ public enum GroupErrorCode implements ErrorCode {
     GROUP_FORBIDDEN(HttpStatus.FORBIDDEN, "그룹 관리 권한이 없습니다."),
     GROUP_ACCESS_DENIED(HttpStatus.FORBIDDEN, "그룹에 접근할 권한이 없습니다."),
     GROUP_INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "캐릭터 그룹에는 ZTPI 캐릭터를 지정해야 합니다."),
+    GROUP_CATEGORY_NOT_SET(HttpStatus.BAD_REQUEST, "캐릭터 유형이 설정되지 않았습니다."),
+    GROUP_TYPE_REQUIRED(HttpStatus.BAD_REQUEST, "그룹 타입을 지정해야 합니다."),
+    GROUP_CHARACTER_IMMUTABLE(HttpStatus.FORBIDDEN, "캐릭터 그룹은 수정하거나 삭제할 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/GroupController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/GroupController.java
@@ -3,11 +3,14 @@ package com.dnd5.timoapi.domain.group.presentation;
 import com.dnd5.timoapi.domain.group.application.service.GroupService;
 import com.dnd5.timoapi.domain.group.presentation.request.GroupCreateRequest;
 import com.dnd5.timoapi.domain.group.presentation.request.GroupUpdateRequest;
+import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupCreateResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupDetailResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupResponse;
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupReflectionSort;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupTodayReflectionItem;
+import com.dnd5.timoapi.domain.group.exception.GroupErrorCode;
+import com.dnd5.timoapi.global.exception.BusinessException;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
@@ -60,10 +63,18 @@ public class GroupController {
         groupService.deleteGroup(groupId);
     }
 
-    @PostMapping("/{groupId}/members")
+    @PostMapping("/members")
     @ResponseStatus(HttpStatus.CREATED)
-    public void joinGroup(@Positive @PathVariable Long groupId) {
-        groupService.joinGroup(groupId);
+    public void joinGroup(
+            @RequestParam(required = false) GroupType type,
+            @RequestParam(required = false) String code) {
+        if (type == GroupType.FRIEND && code != null) {
+            groupService.joinGroupByCode(code);
+        } else if (type == GroupType.CHARACTER) {
+            groupService.joinCharacterGroup();
+        } else {
+            throw new BusinessException(GroupErrorCode.GROUP_TYPE_REQUIRED);
+        }
     }
 
     @DeleteMapping("/{groupId}/members")

--- a/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupServiceTest.java
+++ b/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupServiceTest.java
@@ -257,6 +257,10 @@ class GroupServiceTest {
         Long userId = 1L;
         Long groupId = 10L;
 
+        GroupEntity groupEntity = mock(GroupEntity.class);
+        when(groupEntity.getType()).thenReturn(GroupType.FRIEND);
+        when(groupRepository.findByIdAndDeletedAtIsNull(groupId)).thenReturn(Optional.of(groupEntity));
+
         GroupMemberEntity member = mock(GroupMemberEntity.class);
         when(member.getRole()).thenReturn(GroupMemberRole.MEMBER);
         when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)).thenReturn(Optional.of(member));
@@ -272,18 +276,21 @@ class GroupServiceTest {
     }
 
     @Test
-    void joinGroup_이미_참여중이면_409() {
+    void joinGroupByCode_이미_참여중이면_409() {
         Long userId = 1L;
+        String code = "ABCD1234";
         Long groupId = 10L;
 
         GroupEntity groupEntity = mock(GroupEntity.class);
-        when(groupRepository.findByIdAndDeletedAtIsNull(groupId)).thenReturn(Optional.of(groupEntity));
+        when(groupEntity.getType()).thenReturn(GroupType.FRIEND);
+        when(groupEntity.getId()).thenReturn(groupId);
+        when(groupRepository.findByCodeAndDeletedAtIsNull(code)).thenReturn(Optional.of(groupEntity));
         when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)).thenReturn(true);
 
         try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
             mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-            assertThatThrownBy(() -> groupService.joinGroup(groupId))
+            assertThatThrownBy(() -> groupService.joinGroupByCode(code))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(GroupErrorCode.GROUP_ALREADY_JOINED));
@@ -291,21 +298,24 @@ class GroupServiceTest {
     }
 
     @Test
-    void joinGroup_탈퇴후_재가입시_restore() {
+    void joinGroupByCode_탈퇴후_재가입시_restore() {
         Long userId = 1L;
+        String code = "ABCD1234";
         Long groupId = 10L;
 
         GroupEntity groupEntity = mock(GroupEntity.class);
+        when(groupEntity.getType()).thenReturn(GroupType.FRIEND);
+        when(groupEntity.getId()).thenReturn(groupId);
         GroupMemberEntity softDeletedMember = mock(GroupMemberEntity.class);
 
-        when(groupRepository.findByIdAndDeletedAtIsNull(groupId)).thenReturn(Optional.of(groupEntity));
+        when(groupRepository.findByCodeAndDeletedAtIsNull(code)).thenReturn(Optional.of(groupEntity));
         when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)).thenReturn(false);
         when(groupMemberRepository.findByGroupIdAndUserId(groupId, userId)).thenReturn(Optional.of(softDeletedMember));
 
         try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
             mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-            groupService.joinGroup(groupId);
+            groupService.joinGroupByCode(code);
 
             verify(softDeletedMember).restore();
             verify(groupMemberRepository, never()).save(any());
@@ -425,9 +435,6 @@ class GroupServiceTest {
         when(groupEntity.getType()).thenReturn(GroupType.FRIEND);
         when(groupRepository.findByIdAndDeletedAtIsNull(groupId)).thenReturn(Optional.of(groupEntity));
 
-        GroupMemberEntity member = mock(GroupMemberEntity.class);
-        when(member.getUserId()).thenReturn(2L);
-        when(groupMemberRepository.findAllByGroupIdAndDeletedAtIsNull(groupId)).thenReturn(List.of(member));
         when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)).thenReturn(false);
 
         try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {

--- a/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupServiceTest.java
+++ b/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupServiceTest.java
@@ -317,7 +317,7 @@ class GroupServiceTest {
 
             groupService.joinGroupByCode(code);
 
-            verify(softDeletedMember).restore();
+            verify(softDeletedMember).restoreAsMember();
             verify(groupMemberRepository, never()).save(any());
         }
     }


### PR DESCRIPTION
## What is this PR? :mag:
그룹 가입 API 개편 (POST /groups/members?type=FRIEND|CHARACTER)

## Changes :memo:
- POST /groups/members?type=FRIEND&code=XX → 코드로 친구 그룹 가입
- POST /groups/members?type=CHARACTER → 내 ZtpiCategory 자동 매칭 가입
- PATCH/DELETE /groups/{id} — CHARACTER 그룹 차단 (403)
- getTodayReflectionsForFriendGroup 권한 체크 순서 수정


---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restructured group joining mechanism with type-based routing
  * Enhanced category validation for character group initialization

* **Bug Fixes**
  * Implemented duplicate membership prevention
  * Enforced immutability protection for character group properties

* **Improvements**
  * Enhanced error handling and validation messaging for group operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->