### PR TITLE
feat/statistics

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/reflection/domain/repository/ReflectionFeedbackRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/domain/repository/ReflectionFeedbackRepository.java
@@ -33,4 +33,26 @@ public interface ReflectionFeedbackRepository extends
             @Param("afterDate") LocalDateTime afterDate,
             @Param("excludeReflectionId") Long excludeReflectionId
     );
+
+    @Query("""
+            SELECT rf FROM ReflectionFeedbackEntity rf
+            WHERE rf.reflectionId IN (SELECT r.id FROM ReflectionEntity r WHERE r.userId = :userId)
+            AND rf.status = 'COMPLETED'
+            AND rf.deletedAt IS NULL
+            ORDER BY rf.createdAt ASC
+            """)
+    List<ReflectionFeedbackEntity> findCompletedByUserIdOrderByCreatedAt(@Param("userId") Long userId);
+
+    @Query("""
+            SELECT rf FROM ReflectionFeedbackEntity rf
+            WHERE rf.reflectionId IN (SELECT r.id FROM ReflectionEntity r WHERE r.userId = :userId)
+            AND rf.category = :category
+            AND rf.status = 'COMPLETED'
+            AND rf.deletedAt IS NULL
+            ORDER BY rf.createdAt ASC
+            """)
+    List<ReflectionFeedbackEntity> findCompletedByUserIdAndCategoryOrderByCreatedAt(
+            @Param("userId") Long userId,
+            @Param("category") ZtpiCategory category
+    );
 }

--- a/src/main/java/com/dnd5/timoapi/domain/statistics/application/service/StatisticsService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/statistics/application/service/StatisticsService.java
@@ -1,0 +1,126 @@
+package com.dnd5.timoapi.domain.statistics.application.service;
+
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionFeedbackEntity;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionFeedbackRepository;
+import com.dnd5.timoapi.domain.statistics.presentation.response.StatisticsCategoryDetailResponse;
+import com.dnd5.timoapi.domain.statistics.presentation.response.StatisticsCategoryResponse;
+import com.dnd5.timoapi.domain.statistics.presentation.response.StatisticsResponse;
+import com.dnd5.timoapi.domain.statistics.presentation.response.StatisticsScoreDetailResponse;
+import com.dnd5.timoapi.domain.statistics.presentation.response.StatisticsScoreResponse;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+import com.dnd5.timoapi.domain.user.domain.entity.UserTestRecordEntity;
+import com.dnd5.timoapi.domain.user.domain.entity.UserTestResultEntity;
+import com.dnd5.timoapi.domain.user.domain.model.enums.UserTestRecordStatus;
+import com.dnd5.timoapi.domain.user.domain.repository.UserTestRecordRepository;
+import com.dnd5.timoapi.domain.user.domain.repository.UserTestResultRepository;
+import com.dnd5.timoapi.global.security.context.SecurityUtil;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StatisticsService {
+
+    private final UserTestRecordRepository userTestRecordRepository;
+    private final UserTestResultRepository userTestResultRepository;
+    private final ReflectionFeedbackRepository reflectionFeedbackRepository;
+
+    public StatisticsResponse getStatistics() {
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        Map<ZtpiCategory, UserTestResultEntity> testResultByCategory = getLatestTestResultByCategory(userId);
+        List<ReflectionFeedbackEntity> feedbacks = reflectionFeedbackRepository
+                .findCompletedByUserIdOrderByCreatedAt(userId);
+        Map<ZtpiCategory, List<ReflectionFeedbackEntity>> feedbacksByCategory = feedbacks.stream()
+                .collect(Collectors.groupingBy(ReflectionFeedbackEntity::getCategory));
+
+        List<StatisticsCategoryResponse> categories = Arrays.stream(ZtpiCategory.values())
+                .map(category -> {
+                    List<StatisticsScoreResponse> dataPoints = new ArrayList<>();
+
+                    UserTestResultEntity testResult = testResultByCategory.get(category);
+                    if (testResult != null) {
+                        dataPoints.add(new StatisticsScoreResponse(
+                                testResult.getScore(),
+                                testResult.getCreatedAt(),
+                                "TEST"
+                        ));
+                    }
+
+                    feedbacksByCategory.getOrDefault(category, List.of()).forEach(fb ->
+                            dataPoints.add(new StatisticsScoreResponse(
+                                    fb.getAfterScore(),
+                                    fb.getCreatedAt(),
+                                    "REFLECTION"
+                            ))
+                    );
+
+                    return new StatisticsCategoryResponse(
+                            category,
+                            category.getCharacter(),
+                            category.getPersonality(),
+                            category.getIdealScore(),
+                            dataPoints
+                    );
+                })
+                .toList();
+
+        return new StatisticsResponse(categories);
+    }
+
+    public StatisticsCategoryDetailResponse getCategoryStatistics(ZtpiCategory category) {
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        List<StatisticsScoreDetailResponse> dataPoints = new ArrayList<>();
+
+        getLatestTestResultByCategory(userId).entrySet().stream()
+                .filter(entry -> entry.getKey() == category)
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .ifPresent(testResult -> dataPoints.add(new StatisticsScoreDetailResponse(
+                        testResult.getScore(),
+                        testResult.getCreatedAt(),
+                        "TEST",
+                        null,
+                        null
+                )));
+
+        reflectionFeedbackRepository
+                .findCompletedByUserIdAndCategoryOrderByCreatedAt(userId, category)
+                .forEach(fb -> dataPoints.add(new StatisticsScoreDetailResponse(
+                        fb.getAfterScore(),
+                        fb.getCreatedAt(),
+                        "REFLECTION",
+                        fb.getChangedScore(),
+                        fb.getIsIncreased()
+                )));
+
+        return new StatisticsCategoryDetailResponse(
+                category,
+                category.getCharacter(),
+                category.getPersonality(),
+                category.getIdealScore(),
+                dataPoints
+        );
+    }
+
+    private Map<ZtpiCategory, UserTestResultEntity> getLatestTestResultByCategory(Long userId) {
+        Optional<UserTestRecordEntity> latestRecord = userTestRecordRepository
+                .findTopByUserIdAndStatusOrderByCreatedAtDesc(userId, UserTestRecordStatus.COMPLETED);
+
+        return latestRecord
+                .map(record -> userTestResultRepository
+                        .findAllByUserTestRecordIdAndDeletedAtIsNull(record.getId())
+                        .stream()
+                        .collect(Collectors.toMap(UserTestResultEntity::getCategory, r -> r)))
+                .orElse(Map.of());
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/statistics/application/service/StatisticsService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/statistics/application/service/StatisticsService.java
@@ -11,14 +11,15 @@ import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import com.dnd5.timoapi.domain.user.domain.entity.UserTestRecordEntity;
 import com.dnd5.timoapi.domain.user.domain.entity.UserTestResultEntity;
 import com.dnd5.timoapi.domain.user.domain.model.enums.UserTestRecordStatus;
+import com.dnd5.timoapi.domain.statistics.exception.StatisticsErrorCode;
 import com.dnd5.timoapi.domain.user.domain.repository.UserTestRecordRepository;
 import com.dnd5.timoapi.domain.user.domain.repository.UserTestResultRepository;
+import com.dnd5.timoapi.global.exception.BusinessException;
 import com.dnd5.timoapi.global.security.context.SecurityUtil;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -113,14 +114,18 @@ public class StatisticsService {
     }
 
     private Map<ZtpiCategory, UserTestResultEntity> getLatestTestResultByCategory(Long userId) {
-        Optional<UserTestRecordEntity> latestRecord = userTestRecordRepository
-                .findTopByUserIdAndStatusOrderByCreatedAtDesc(userId, UserTestRecordStatus.COMPLETED);
+        UserTestRecordEntity latestRecord = userTestRecordRepository
+                .findTopByUserIdAndStatusOrderByCreatedAtDesc(userId, UserTestRecordStatus.COMPLETED)
+                .orElseThrow(() -> new BusinessException(StatisticsErrorCode.STATISTICS_TEST_NOT_COMPLETED));
 
-        return latestRecord
-                .map(record -> userTestResultRepository
-                        .findAllByUserTestRecordIdAndDeletedAtIsNull(record.getId())
-                        .stream()
-                        .collect(Collectors.toMap(UserTestResultEntity::getCategory, r -> r)))
-                .orElse(Map.of());
+        List<UserTestResultEntity> results = userTestResultRepository
+                .findAllByUserTestRecordIdAndDeletedAtIsNull(latestRecord.getId());
+
+        if (results.isEmpty()) {
+            throw new BusinessException(StatisticsErrorCode.STATISTICS_TEST_RESULT_NOT_FOUND);
+        }
+
+        return results.stream()
+                .collect(Collectors.toMap(UserTestResultEntity::getCategory, r -> r));
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/statistics/exception/StatisticsErrorCode.java
+++ b/src/main/java/com/dnd5/timoapi/domain/statistics/exception/StatisticsErrorCode.java
@@ -1,0 +1,17 @@
+package com.dnd5.timoapi.domain.statistics.exception;
+
+import com.dnd5.timoapi.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum StatisticsErrorCode implements ErrorCode {
+
+    STATISTICS_TEST_NOT_COMPLETED(HttpStatus.NOT_FOUND, "완료된 ZTPI 테스트 기록이 없습니다."),
+    STATISTICS_TEST_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "테스트 결과 데이터가 존재하지 않습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/StatisticsController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/StatisticsController.java
@@ -1,0 +1,29 @@
+package com.dnd5.timoapi.domain.statistics.presentation;
+
+import com.dnd5.timoapi.domain.statistics.application.service.StatisticsService;
+import com.dnd5.timoapi.domain.statistics.presentation.response.StatisticsCategoryDetailResponse;
+import com.dnd5.timoapi.domain.statistics.presentation.response.StatisticsResponse;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/statistics")
+@RequiredArgsConstructor
+public class StatisticsController {
+
+    private final StatisticsService statisticsService;
+
+    @GetMapping
+    public StatisticsResponse getStatistics() {
+        return statisticsService.getStatistics();
+    }
+
+    @GetMapping("/{category}")
+    public StatisticsCategoryDetailResponse getCategoryStatistics(@PathVariable ZtpiCategory category) {
+        return statisticsService.getCategoryStatistics(category);
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/response/StatisticsCategoryDetailResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/response/StatisticsCategoryDetailResponse.java
@@ -1,0 +1,14 @@
+package com.dnd5.timoapi.domain.statistics.presentation.response;
+
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+import java.util.List;
+
+public record StatisticsCategoryDetailResponse(
+        ZtpiCategory category,
+        String character,
+        String personality,
+        double idealScore,
+        List<StatisticsScoreDetailResponse> dataPoints
+) {
+
+}

--- a/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/response/StatisticsCategoryResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/response/StatisticsCategoryResponse.java
@@ -1,0 +1,14 @@
+package com.dnd5.timoapi.domain.statistics.presentation.response;
+
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+import java.util.List;
+
+public record StatisticsCategoryResponse(
+        ZtpiCategory category,
+        String character,
+        String personality,
+        double idealScore,
+        List<StatisticsScoreResponse> dataPoints
+) {
+
+}

--- a/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/response/StatisticsResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/response/StatisticsResponse.java
@@ -1,0 +1,9 @@
+package com.dnd5.timoapi.domain.statistics.presentation.response;
+
+import java.util.List;
+
+public record StatisticsResponse(
+        List<StatisticsCategoryResponse> categories
+) {
+
+}

--- a/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/response/StatisticsScoreDetailResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/response/StatisticsScoreDetailResponse.java
@@ -1,0 +1,13 @@
+package com.dnd5.timoapi.domain.statistics.presentation.response;
+
+import java.time.LocalDateTime;
+
+public record StatisticsScoreDetailResponse(
+        double score,
+        LocalDateTime createdAt,
+        String type,
+        Double changedScore,
+        Boolean isIncreased
+) {
+
+}

--- a/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/response/StatisticsScoreResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/response/StatisticsScoreResponse.java
@@ -1,0 +1,11 @@
+package com.dnd5.timoapi.domain.statistics.presentation.response;
+
+import java.time.LocalDateTime;
+
+public record StatisticsScoreResponse(
+        double score,
+        LocalDateTime createdAt,
+        String type
+) {
+
+}


### PR DESCRIPTION
## What is this PR? :mag:
ZTPI 시간관 수치 변화를 그래프로 표시하기 위한 통계 조회 API를 추가했습니다.
가장 최근에 진행한 테스트 기록부터 이후 회고 기록들을 dataPoints 객체에 담아 응답합니다.

## Changes :memo:
- GET /statistics — 5개 카테고리 전체 점수 변화 조회
- GET /statistics/{category} — 카테고리별 상세 점수 변화 조회
- 테스트 초기 점수(TEST)와 회고 피드백 점수 변화(REFLECTION)를 시간순 dataPoints로 반환
- statistics 신규 도메인 추가 (application, presentation, exception 레이어)
- 완료된 테스트 기록 없음 / 결과 데이터 없음에 대한 오류 검증 로직 추가

---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added statistics endpoints to view overall performance metrics across all assessment categories
  * Added detailed category-specific statistics with score changes and performance trends

<!-- end of auto-generated comment: release notes by coderabbit.ai -->