### PR TITLE
feat/statistics-ideal-proximity

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/statistics/application/service/StatisticsService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/statistics/application/service/StatisticsService.java
@@ -131,7 +131,7 @@ public class StatisticsService {
     private record ProximityInfo(Double changedScore, Double proximityRate, Boolean isCloserToIdeal) {}
 
     private ProximityInfo calculateProximity(ReflectionFeedbackEntity feedback, double idealScore) {
-        if (feedback == null || feedback.getChangedScore() == null) {
+        if (feedback == null || feedback.getChangedScore() == null || feedback.getBeforeScore() == null || feedback.getAfterScore() == null) {
             return new ProximityInfo(null, null, null);
         }
 

--- a/src/main/java/com/dnd5/timoapi/domain/statistics/application/service/StatisticsService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/statistics/application/service/StatisticsService.java
@@ -56,7 +56,8 @@ public class StatisticsService {
                         ));
                     }
 
-                    feedbacksByCategory.getOrDefault(category, List.of()).forEach(fb ->
+                    List<ReflectionFeedbackEntity> categoryFeedbacks = feedbacksByCategory.getOrDefault(category, List.of());
+                    categoryFeedbacks.forEach(fb ->
                             dataPoints.add(new StatisticsScoreResponse(
                                     fb.getAfterScore(),
                                     fb.getCreatedAt(),
@@ -64,11 +65,18 @@ public class StatisticsService {
                             ))
                     );
 
+                    ReflectionFeedbackEntity latestFeedback = categoryFeedbacks.isEmpty()
+                            ? null : categoryFeedbacks.get(categoryFeedbacks.size() - 1);
+                    ProximityInfo proximity = calculateProximity(latestFeedback, category.getIdealScore());
+
                     return new StatisticsCategoryResponse(
                             category,
                             category.getCharacter(),
                             category.getPersonality(),
                             category.getIdealScore(),
+                            proximity.changedScore(),
+                            proximity.proximityRate(),
+                            proximity.isCloserToIdeal(),
                             dataPoints
                     );
                 })
@@ -94,23 +102,50 @@ public class StatisticsService {
                         null
                 )));
 
-        reflectionFeedbackRepository
-                .findCompletedByUserIdAndCategoryOrderByCreatedAt(userId, category)
-                .forEach(fb -> dataPoints.add(new StatisticsScoreDetailResponse(
-                        fb.getAfterScore(),
-                        fb.getCreatedAt(),
-                        "REFLECTION",
-                        fb.getChangedScore(),
-                        fb.getIsIncreased()
-                )));
+        List<ReflectionFeedbackEntity> feedbacks = reflectionFeedbackRepository
+                .findCompletedByUserIdAndCategoryOrderByCreatedAt(userId, category);
+
+        feedbacks.forEach(fb -> dataPoints.add(new StatisticsScoreDetailResponse(
+                fb.getAfterScore(),
+                fb.getCreatedAt(),
+                "REFLECTION",
+                fb.getChangedScore(),
+                fb.getIsIncreased()
+        )));
+
+        ReflectionFeedbackEntity latestFeedback = feedbacks.isEmpty() ? null : feedbacks.get(feedbacks.size() - 1);
+        ProximityInfo proximity = calculateProximity(latestFeedback, category.getIdealScore());
 
         return new StatisticsCategoryDetailResponse(
                 category,
                 category.getCharacter(),
                 category.getPersonality(),
                 category.getIdealScore(),
+                proximity.changedScore(),
+                proximity.proximityRate(),
+                proximity.isCloserToIdeal(),
                 dataPoints
         );
+    }
+
+    private record ProximityInfo(Double changedScore, Double proximityRate, Boolean isCloserToIdeal) {}
+
+    private ProximityInfo calculateProximity(ReflectionFeedbackEntity feedback, double idealScore) {
+        if (feedback == null || feedback.getChangedScore() == null) {
+            return new ProximityInfo(null, null, null);
+        }
+
+        double previousDistance = Math.abs(idealScore - feedback.getBeforeScore());
+        double currentDistance = Math.abs(idealScore - feedback.getAfterScore());
+
+        if (previousDistance == 0) {
+            return new ProximityInfo(feedback.getChangedScore(), null, null);
+        }
+
+        double proximityRate = Math.abs(previousDistance - currentDistance) / previousDistance * 100;
+        boolean isCloserToIdeal = currentDistance < previousDistance;
+
+        return new ProximityInfo(feedback.getChangedScore(), proximityRate, isCloserToIdeal);
     }
 
     private Map<ZtpiCategory, UserTestResultEntity> getLatestTestResultByCategory(Long userId) {

--- a/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/response/StatisticsCategoryDetailResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/response/StatisticsCategoryDetailResponse.java
@@ -8,6 +8,9 @@ public record StatisticsCategoryDetailResponse(
         String character,
         String personality,
         double idealScore,
+        Double changedScore,
+        Double proximityRate,
+        Boolean isCloserToIdeal,
         List<StatisticsScoreDetailResponse> dataPoints
 ) {
 

--- a/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/response/StatisticsCategoryResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/response/StatisticsCategoryResponse.java
@@ -8,6 +8,9 @@ public record StatisticsCategoryResponse(
         String character,
         String personality,
         double idealScore,
+        Double changedScore,
+        Double proximityRate,
+        Boolean isCloserToIdeal,
         List<StatisticsScoreResponse> dataPoints
 ) {
 


### PR DESCRIPTION
## What is this PR? :mag:
통계 카테고리 응답에 이상치 근접도 정보 추가

## Changes :memo:
- changedScore: 최신 회고 점수 변화량
- proximityRate: 이상치 근접도 변화율 (%)
- isCloserToIdeal: 이상치에 가까워졌는지 여부

GET /statistics와 GET /statistics/{category} 두 개 API 응답에 위 세 가지 속성을 추가했습니다.

---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added proximity metrics to category statistics showing distance from ideal scores.
  * Extended statistics responses to include score changes and progress indicators toward ideal targets.
  * Enhanced overall and per-category statistics with proximity rate information for better performance insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->