### PR TITLE
chore/swagger-settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,9 @@ dependencies {
     // Firebase
     implementation 'com.google.firebase:firebase-admin:9.4.2'
 
+    // Swagger (SpringDoc OpenAPI)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
+
     // Test
     testImplementation 'com.h2database:h2'
 }

--- a/src/main/java/com/dnd5/timoapi/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/dnd5/timoapi/global/security/config/SecurityConfig.java
@@ -47,7 +47,9 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() { // security를 적용하지 않을 리소스
         return web -> web.ignoring()
                 // error endpoint를 열어줘야 함, favicon.ico 추가!
-                .requestMatchers("/error", "/favicon.ico");
+                .requestMatchers("/error", "/favicon.ico")
+                // Swagger UI
+                .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**");
     }
 
     @Bean

--- a/src/main/java/com/dnd5/timoapi/global/swagger/SwaggerConfig.java
+++ b/src/main/java/com/dnd5/timoapi/global/swagger/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package com.dnd5.timoapi.global.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        String securitySchemeName = "bearerAuth";
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("TIMO API")
+                        .description("TIMO 서비스 API 명세서")
+                        .version("v1.0.0"))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName, new SecurityScheme()
+                                .name(securitySchemeName)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -73,6 +73,12 @@ spring:
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
 
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+
 logging:
   level:
     root: INFO


### PR DESCRIPTION
## What is this PR? :mag:
chore: Swagger(SpringDoc OpenAPI) 설정 추가

## Changes :memo:
- springdoc-openapi 3.0.3 의존성 추가 (build.gradle)
- SwaggerConfig 클래스 추가 — API 그룹 및 메타 정보 설정
- SecurityConfig에서 Swagger UI 엔드포인트 인증 제외 처리 (`/swagger-ui/**`, `/v3/api-docs/**`)
- application-prod.yml에 Swagger UI 활성화 설정 추가 (현재 활성화 처리)

## Screenshot  :camera:



---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive API documentation support with Swagger/OpenAPI.
  * Configured API metadata and bearer-token authentication details in the generated docs.

* **Bug Fixes**
  * Allowed documentation endpoints to load without being blocked by security filters.
  * Enabled API docs and Swagger UI in the production environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->