### PR TITLE
feat/customization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ com.dnd5.timoapi
 | introduction | 자기소개 |
 | notification | FCM 푸시, 알림 이력 |
 | test | ZTPI 성격 검사 문항 |
+| customization | 캐릭터 커스터마이징 아이템(테마/장식) 관리, 회고 활동 기반 해금 |
 
 ## 핵심 코드 패턴
 

--- a/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
@@ -1,0 +1,166 @@
+package com.dnd5.timoapi.domain.customization.application.service;
+
+import com.dnd5.timoapi.domain.customization.domain.entity.CustomizationItemEntity;
+import com.dnd5.timoapi.domain.customization.domain.entity.CustomizationUserItemEntity;
+import com.dnd5.timoapi.domain.customization.domain.model.CustomizationItem;
+import com.dnd5.timoapi.domain.customization.domain.model.CustomizationUserItem;
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationUnlockConditionType;
+import com.dnd5.timoapi.domain.customization.domain.repository.CustomizationItemRepository;
+import com.dnd5.timoapi.domain.customization.domain.repository.CustomizationUserItemRepository;
+import com.dnd5.timoapi.domain.customization.exception.CustomizationItemErrorCode;
+import com.dnd5.timoapi.domain.customization.presentation.request.CustomizationItemCreateRequest;
+import com.dnd5.timoapi.domain.customization.presentation.request.CustomizationItemUpdateRequest;
+import com.dnd5.timoapi.domain.customization.presentation.response.CustomizationItemDetailResponse;
+import com.dnd5.timoapi.domain.customization.presentation.response.CustomizationItemResponse;
+import com.dnd5.timoapi.domain.customization.presentation.response.EquippedCustomizationResponse;
+import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
+import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
+import com.dnd5.timoapi.domain.user.exception.UserErrorCode;
+import com.dnd5.timoapi.global.exception.BusinessException;
+import com.dnd5.timoapi.global.security.context.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CustomizationItemService {
+
+    private final CustomizationItemRepository customizationItemRepository;
+    private final CustomizationUserItemRepository customizationUserItemRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public List<CustomizationItemResponse> findAll() {
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        Map<Long, CustomizationUserItemEntity> userItemsByItemId = customizationUserItemRepository
+                .findAllByUserIdAndDeletedAtIsNull(userId).stream()
+                .collect(Collectors.toMap(CustomizationUserItemEntity::getCustomizationItemId, Function.identity()));
+
+        return customizationItemRepository.findAllByDeletedAtIsNull().stream()
+                .map(itemEntity -> {
+                    CustomizationUserItemEntity userItem = userItemsByItemId.get(itemEntity.getId());
+                    boolean isUnlocked = userItem != null && userItem.isUnlocked();
+                    boolean isEquipped = userItem != null && userItem.isEquipped();
+                    return CustomizationItemResponse.from(itemEntity.toModel(), isUnlocked, isEquipped);
+                })
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<EquippedCustomizationResponse> findEquippedItems(Long userId) {
+        List<CustomizationUserItemEntity> equippedUserItems = customizationUserItemRepository
+                .findAllByUserIdAndIsEquippedTrueAndDeletedAtIsNull(userId);
+
+        if (equippedUserItems.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> itemIds = equippedUserItems.stream()
+                .map(CustomizationUserItemEntity::getCustomizationItemId)
+                .toList();
+
+        Map<Long, CustomizationItemEntity> itemsById = customizationItemRepository.findAllById(itemIds).stream()
+                .collect(Collectors.toMap(CustomizationItemEntity::getId, Function.identity()));
+
+        return equippedUserItems.stream()
+                .map(userItem -> itemsById.get(userItem.getCustomizationItemId()))
+                .filter(item -> item != null)
+                .map(item -> EquippedCustomizationResponse.from(item.toModel()))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public CustomizationItemDetailResponse findById(Long customizationItemId) {
+        CustomizationItemEntity entity = getCustomizationItemEntity(customizationItemId);
+        return CustomizationItemDetailResponse.from(entity.toModel());
+    }
+
+    public void create(CustomizationItemCreateRequest request) {
+        CustomizationItem model = request.toModel();
+        customizationItemRepository.save(CustomizationItemEntity.from(model));
+    }
+
+    public void update(Long customizationItemId, CustomizationItemUpdateRequest request) {
+        CustomizationItemEntity entity = getCustomizationItemEntity(customizationItemId);
+        entity.update(
+                request.name(),
+                request.type(),
+                request.description(),
+                request.unlockConditionType(),
+                request.unlockConditionCount(),
+                request.image()
+        );
+    }
+
+    public void delete(Long customizationItemId) {
+        CustomizationItemEntity entity = getCustomizationItemEntity(customizationItemId);
+        entity.softDelete();
+    }
+
+    public void unlockEligibleItems(Long userId) {
+        UserEntity user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        Map<Long, CustomizationUserItemEntity> userItemsByItemId = customizationUserItemRepository
+                .findAllByUserIdAndDeletedAtIsNull(userId).stream()
+                .collect(Collectors.toMap(CustomizationUserItemEntity::getCustomizationItemId, Function.identity()));
+
+        customizationItemRepository.findAllByDeletedAtIsNull().stream()
+                .filter(item -> isUnlockConditionMet(item, user))
+                .forEach(item -> {
+                    CustomizationUserItemEntity userItem = userItemsByItemId.get(item.getId());
+                    if (userItem == null) {
+                        CustomizationUserItemEntity newUserItem = CustomizationUserItemEntity.from(
+                                CustomizationUserItem.create(userId, item.getId()));
+                        newUserItem.unlock();
+                        customizationUserItemRepository.save(newUserItem);
+                    } else if (!userItem.isUnlocked()) {
+                        userItem.unlock();
+                    }
+                });
+    }
+
+    public void revokeStreakUnlocksFor(List<Long> userIds) {
+        if (userIds.isEmpty()) {
+            return;
+        }
+
+        List<Long> streakItemIds = customizationItemRepository.findAllByDeletedAtIsNull().stream()
+                .filter(item -> item.getUnlockConditionType() == CustomizationUnlockConditionType.STREAK_COUNT)
+                .map(CustomizationItemEntity::getId)
+                .toList();
+
+        if (streakItemIds.isEmpty()) {
+            return;
+        }
+
+        customizationUserItemRepository
+                .findAllByUserIdInAndCustomizationItemIdInAndIsUnlockedTrueAndDeletedAtIsNull(userIds, streakItemIds)
+                .forEach(userItem -> {
+                    userItem.lock();
+                    if (userItem.isEquipped()) {
+                        userItem.unequip();
+                    }
+                });
+    }
+
+    private boolean isUnlockConditionMet(CustomizationItemEntity item, UserEntity user) {
+        return switch (item.getUnlockConditionType()) {
+            case TOTAL_COUNT -> item.getUnlockConditionCount() <= user.getTotalDays();
+            case STREAK_COUNT -> item.getUnlockConditionCount() <= user.getStreakDays();
+        };
+    }
+
+    private CustomizationItemEntity getCustomizationItemEntity(Long customizationItemId) {
+        return customizationItemRepository.findByIdAndDeletedAtIsNull(customizationItemId)
+                .orElseThrow(() -> new BusinessException(CustomizationItemErrorCode.CUSTOMIZATION_ITEM_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
@@ -14,6 +14,7 @@ import com.dnd5.timoapi.domain.customization.presentation.request.CustomizationI
 import com.dnd5.timoapi.domain.customization.presentation.response.CustomizationItemDetailResponse;
 import com.dnd5.timoapi.domain.customization.presentation.response.CustomizationItemResponse;
 import com.dnd5.timoapi.domain.customization.presentation.response.EquippedCustomizationResponse;
+import com.dnd5.timoapi.domain.customization.presentation.response.UnlockedCustomizationItemResponse;
 import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
 import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
 import com.dnd5.timoapi.domain.user.exception.UserErrorCode;
@@ -23,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -146,7 +148,7 @@ public class CustomizationItemService {
         userItem.unequip();
     }
 
-    public void unlockEligibleItems(Long userId) {
+    public List<UnlockedCustomizationItemResponse> unlockEligibleItems(Long userId) {
         UserEntity user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
@@ -154,19 +156,31 @@ public class CustomizationItemService {
                 .findAllByUserIdAndDeletedAtIsNull(userId).stream()
                 .collect(Collectors.toMap(CustomizationUserItemEntity::getCustomizationItemId, Function.identity()));
 
-        customizationItemRepository.findAllByDeletedAtIsNull().stream()
-                .filter(item -> isUnlockConditionMet(item, user))
-                .forEach(item -> {
-                    CustomizationUserItemEntity userItem = userItemsByItemId.get(item.getId());
-                    if (userItem == null) {
-                        CustomizationUserItemEntity newUserItem = CustomizationUserItemEntity.from(
-                                CustomizationUserItem.create(userId, item.getId()));
-                        newUserItem.unlock();
-                        customizationUserItemRepository.save(newUserItem);
-                    } else if (!userItem.isUnlocked()) {
-                        userItem.unlock();
-                    }
-                });
+        List<UnlockedCustomizationItemResponse> newlyUnlocked = new ArrayList<>();
+
+        for (CustomizationItemEntity item : customizationItemRepository.findAllByDeletedAtIsNull()) {
+            if (!isUnlockConditionMet(item, user)) {
+                continue;
+            }
+
+            CustomizationUserItemEntity userItem = userItemsByItemId.get(item.getId());
+            if (userItem != null && userItem.isUnlocked()) {
+                continue;
+            }
+
+            if (userItem == null) {
+                CustomizationUserItemEntity newUserItem = CustomizationUserItemEntity.from(
+                        CustomizationUserItem.create(userId, item.getId()));
+                newUserItem.unlock();
+                customizationUserItemRepository.save(newUserItem);
+            } else {
+                userItem.unlock();
+            }
+
+            newlyUnlocked.add(UnlockedCustomizationItemResponse.from(item.toModel()));
+        }
+
+        return newlyUnlocked;
     }
 
     public void revokeStreakUnlocksFor(List<Long> userIds) {

--- a/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
@@ -4,6 +4,7 @@ import com.dnd5.timoapi.domain.customization.domain.entity.CustomizationItemEnti
 import com.dnd5.timoapi.domain.customization.domain.entity.CustomizationUserItemEntity;
 import com.dnd5.timoapi.domain.customization.domain.model.CustomizationItem;
 import com.dnd5.timoapi.domain.customization.domain.model.CustomizationUserItem;
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationItemType;
 import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationUnlockConditionType;
 import com.dnd5.timoapi.domain.customization.domain.repository.CustomizationItemRepository;
 import com.dnd5.timoapi.domain.customization.domain.repository.CustomizationUserItemRepository;
@@ -24,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -103,6 +105,45 @@ public class CustomizationItemService {
     public void delete(Long customizationItemId) {
         CustomizationItemEntity entity = getCustomizationItemEntity(customizationItemId);
         entity.softDelete();
+    }
+
+    public void equip(Long userId, Long customizationItemId) {
+        CustomizationItemEntity item = getCustomizationItemEntity(customizationItemId);
+
+        CustomizationUserItemEntity userItem = customizationUserItemRepository
+                .findByUserIdAndCustomizationItemIdAndDeletedAtIsNull(userId, customizationItemId)
+                .orElseThrow(() -> new BusinessException(
+                        CustomizationItemErrorCode.CUSTOMIZATION_ITEM_NOT_UNLOCKED, customizationItemId));
+
+        if (!userItem.isUnlocked()) {
+            throw new BusinessException(CustomizationItemErrorCode.CUSTOMIZATION_ITEM_NOT_UNLOCKED, customizationItemId);
+        }
+
+        if (item.getType() == CustomizationItemType.THEME) {
+            customizationUserItemRepository.findAllByUserIdAndIsEquippedTrueAndDeletedAtIsNull(userId).stream()
+                    .filter(equipped -> !equipped.getCustomizationItemId().equals(customizationItemId))
+                    .map(equipped -> customizationItemRepository.findById(equipped.getCustomizationItemId()))
+                    .flatMap(Optional::stream)
+                    .filter(equippedItem -> equippedItem.getType() == CustomizationItemType.THEME)
+                    .findFirst()
+                    .ifPresent(equippedItem -> {
+                        throw new BusinessException(
+                                CustomizationItemErrorCode.CUSTOMIZATION_THEME_ALREADY_EQUIPPED, equippedItem.getId());
+                    });
+        }
+
+        userItem.equip();
+    }
+
+    public void unequip(Long userId, Long customizationItemId) {
+        getCustomizationItemEntity(customizationItemId);
+
+        CustomizationUserItemEntity userItem = customizationUserItemRepository
+                .findByUserIdAndCustomizationItemIdAndDeletedAtIsNull(userId, customizationItemId)
+                .orElseThrow(() -> new BusinessException(
+                        CustomizationItemErrorCode.CUSTOMIZATION_ITEM_NOT_UNLOCKED, customizationItemId));
+
+        userItem.unequip();
     }
 
     public void unlockEligibleItems(Long userId) {

--- a/src/main/java/com/dnd5/timoapi/domain/customization/domain/entity/CustomizationItemEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/domain/entity/CustomizationItemEntity.java
@@ -1,0 +1,85 @@
+package com.dnd5.timoapi.domain.customization.domain.entity;
+
+import com.dnd5.timoapi.domain.customization.domain.model.CustomizationItem;
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationItemType;
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationUnlockConditionType;
+import com.dnd5.timoapi.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(name = "customization_items")
+public class CustomizationItemEntity extends BaseEntity {
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private CustomizationItemType type;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private CustomizationUnlockConditionType unlockConditionType;
+
+    @Column(nullable = false)
+    private Integer unlockConditionCount;
+
+    @Column(columnDefinition = "TEXT")
+    private String image;
+
+    public static CustomizationItemEntity from(CustomizationItem model) {
+        return new CustomizationItemEntity(
+                model.name(),
+                model.type(),
+                model.description(),
+                model.unlockConditionType(),
+                model.unlockConditionCount(),
+                model.image()
+        );
+    }
+
+    public CustomizationItem toModel() {
+        return new CustomizationItem(
+                getId(),
+                getName(),
+                getType(),
+                getDescription(),
+                getUnlockConditionType(),
+                getUnlockConditionCount(),
+                getImage(),
+                getCreatedAt(),
+                getUpdatedAt(),
+                getDeletedAt()
+        );
+    }
+
+    public void update(
+            String name,
+            CustomizationItemType type,
+            String description,
+            CustomizationUnlockConditionType unlockConditionType,
+            Integer unlockConditionCount,
+            String image
+    ) {
+        if (name != null) this.name = name;
+        if (type != null) this.type = type;
+        if (description != null) this.description = description;
+        if (unlockConditionType != null) this.unlockConditionType = unlockConditionType;
+        if (unlockConditionCount != null) this.unlockConditionCount = unlockConditionCount;
+        if (image != null) this.image = image;
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/domain/entity/CustomizationUserItemEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/domain/entity/CustomizationUserItemEntity.java
@@ -1,0 +1,69 @@
+package com.dnd5.timoapi.domain.customization.domain.entity;
+
+import com.dnd5.timoapi.domain.customization.domain.model.CustomizationUserItem;
+import com.dnd5.timoapi.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(
+        name = "customization_user_items",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "customization_item_id"})
+)
+public class CustomizationUserItemEntity extends BaseEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "customization_item_id", nullable = false)
+    private Long customizationItemId;
+
+    @Column(nullable = false)
+    private boolean isUnlocked;
+
+    @Column(nullable = false)
+    private boolean isEquipped;
+
+    public static CustomizationUserItemEntity from(CustomizationUserItem model) {
+        return new CustomizationUserItemEntity(
+                model.userId(),
+                model.customizationItemId(),
+                model.isUnlocked(),
+                model.isEquipped()
+        );
+    }
+
+    public CustomizationUserItem toModel() {
+        return new CustomizationUserItem(
+                getId(),
+                getUserId(),
+                getCustomizationItemId(),
+                isUnlocked(),
+                isEquipped(),
+                getCreatedAt(),
+                getUpdatedAt(),
+                getDeletedAt()
+        );
+    }
+
+    public void lock() { this.isUnlocked = false; }
+
+    public void unlock() { this.isUnlocked = true; }
+
+    public void equip() {
+        this.isEquipped = true;
+    }
+
+    public void unequip() {
+        this.isEquipped = false;
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/domain/model/CustomizationItem.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/domain/model/CustomizationItem.java
@@ -1,0 +1,30 @@
+package com.dnd5.timoapi.domain.customization.domain.model;
+
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationItemType;
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationUnlockConditionType;
+
+import java.time.LocalDateTime;
+
+public record CustomizationItem(
+        Long id,
+        String name,
+        CustomizationItemType type,
+        String description,
+        CustomizationUnlockConditionType unlockConditionType,
+        Integer unlockConditionCount,
+        String image,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        LocalDateTime deletedAt
+) {
+    public static CustomizationItem create(
+            String name,
+            CustomizationItemType type,
+            String description,
+            CustomizationUnlockConditionType unlockConditionType,
+            Integer unlockConditionCount,
+            String image
+    ) {
+        return new CustomizationItem(null, name, type, description, unlockConditionType, unlockConditionCount, image, null, null, null);
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/domain/model/CustomizationUserItem.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/domain/model/CustomizationUserItem.java
@@ -1,0 +1,18 @@
+package com.dnd5.timoapi.domain.customization.domain.model;
+
+import java.time.LocalDateTime;
+
+public record CustomizationUserItem(
+        Long id,
+        Long userId,
+        Long customizationItemId,
+        boolean isUnlocked,
+        boolean isEquipped,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        LocalDateTime deletedAt
+) {
+    public static CustomizationUserItem create(Long userId, Long customizationItemId) {
+        return new CustomizationUserItem(null, userId, customizationItemId, false, false, null, null, null);
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/domain/model/enums/CustomizationItemType.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/domain/model/enums/CustomizationItemType.java
@@ -1,0 +1,6 @@
+package com.dnd5.timoapi.domain.customization.domain.model.enums;
+
+public enum CustomizationItemType {
+    THEME,
+    DECORATION
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/domain/model/enums/CustomizationUnlockConditionType.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/domain/model/enums/CustomizationUnlockConditionType.java
@@ -1,0 +1,6 @@
+package com.dnd5.timoapi.domain.customization.domain.model.enums;
+
+public enum CustomizationUnlockConditionType {
+    TOTAL_COUNT,
+    STREAK_COUNT
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/domain/repository/CustomizationItemRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/domain/repository/CustomizationItemRepository.java
@@ -1,0 +1,14 @@
+package com.dnd5.timoapi.domain.customization.domain.repository;
+
+import com.dnd5.timoapi.domain.customization.domain.entity.CustomizationItemEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CustomizationItemRepository extends JpaRepository<CustomizationItemEntity, Long> {
+
+    Optional<CustomizationItemEntity> findByIdAndDeletedAtIsNull(Long id);
+
+    List<CustomizationItemEntity> findAllByDeletedAtIsNull();
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/domain/repository/CustomizationUserItemRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/domain/repository/CustomizationUserItemRepository.java
@@ -1,0 +1,17 @@
+package com.dnd5.timoapi.domain.customization.domain.repository;
+
+import com.dnd5.timoapi.domain.customization.domain.entity.CustomizationUserItemEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface CustomizationUserItemRepository extends JpaRepository<CustomizationUserItemEntity, Long> {
+
+    List<CustomizationUserItemEntity> findAllByUserIdAndDeletedAtIsNull(Long userId);
+
+    List<CustomizationUserItemEntity> findAllByUserIdAndIsEquippedTrueAndDeletedAtIsNull(Long userId);
+
+    List<CustomizationUserItemEntity> findAllByUserIdInAndCustomizationItemIdInAndIsUnlockedTrueAndDeletedAtIsNull(
+            Collection<Long> userIds, Collection<Long> customizationItemIds);
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/domain/repository/CustomizationUserItemRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/domain/repository/CustomizationUserItemRepository.java
@@ -5,10 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface CustomizationUserItemRepository extends JpaRepository<CustomizationUserItemEntity, Long> {
 
     List<CustomizationUserItemEntity> findAllByUserIdAndDeletedAtIsNull(Long userId);
+
+    Optional<CustomizationUserItemEntity> findByUserIdAndCustomizationItemIdAndDeletedAtIsNull(
+            Long userId, Long customizationItemId);
 
     List<CustomizationUserItemEntity> findAllByUserIdAndIsEquippedTrueAndDeletedAtIsNull(Long userId);
 

--- a/src/main/java/com/dnd5/timoapi/domain/customization/exception/CustomizationItemErrorCode.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/exception/CustomizationItemErrorCode.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum CustomizationItemErrorCode implements ErrorCode {
 
     CUSTOMIZATION_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "커스터마이징 아이템을 찾을 수 없습니다."),
+    CUSTOMIZATION_ITEM_NOT_UNLOCKED(HttpStatus.FORBIDDEN, "해금되지 않은 커스터마이징 아이템입니다. (customizationItemId: %s)"),
+    CUSTOMIZATION_THEME_ALREADY_EQUIPPED(HttpStatus.CONFLICT, "이미 장착 중인 테마가 있습니다. 먼저 해제해주세요. (equippedItemId: %s)"),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/dnd5/timoapi/domain/customization/exception/CustomizationItemErrorCode.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/exception/CustomizationItemErrorCode.java
@@ -1,0 +1,17 @@
+package com.dnd5.timoapi.domain.customization.exception;
+
+import com.dnd5.timoapi.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CustomizationItemErrorCode implements ErrorCode {
+
+    CUSTOMIZATION_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "커스터마이징 아이템을 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/AdminCustomizationController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/AdminCustomizationController.java
@@ -1,0 +1,52 @@
+package com.dnd5.timoapi.domain.customization.presentation;
+
+import com.dnd5.timoapi.domain.customization.application.service.CustomizationItemService;
+import com.dnd5.timoapi.domain.customization.presentation.request.CustomizationItemCreateRequest;
+import com.dnd5.timoapi.domain.customization.presentation.request.CustomizationItemUpdateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/customizations")
+@RequiredArgsConstructor
+@Validated
+public class AdminCustomizationController {
+
+    private final CustomizationItemService customizationItemService;
+
+    @Operation(summary = "커스터마이징 아이템 생성 (어드민)")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public void create(@Valid @RequestBody CustomizationItemCreateRequest request) {
+        customizationItemService.create(request);
+    }
+
+    @Operation(summary = "커스터마이징 아이템 수정 (어드민)")
+    @PatchMapping("/{customizationItemId}")
+    @ResponseStatus(HttpStatus.OK)
+    public void update(
+            @Positive @PathVariable Long customizationItemId,
+            @Valid @RequestBody CustomizationItemUpdateRequest request
+    ) {
+        customizationItemService.update(customizationItemId, request);
+    }
+
+    @Operation(summary = "커스터마이징 아이템 삭제 (어드민)")
+    @DeleteMapping("/{customizationItemId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@Positive @PathVariable Long customizationItemId) {
+        customizationItemService.delete(customizationItemId);
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/CustomizationController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/CustomizationController.java
@@ -3,13 +3,18 @@ package com.dnd5.timoapi.domain.customization.presentation;
 import com.dnd5.timoapi.domain.customization.application.service.CustomizationItemService;
 import com.dnd5.timoapi.domain.customization.presentation.response.CustomizationItemDetailResponse;
 import com.dnd5.timoapi.domain.customization.presentation.response.CustomizationItemResponse;
+import com.dnd5.timoapi.global.security.context.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -32,5 +37,19 @@ public class CustomizationController {
     @GetMapping("/{customizationItemId}")
     public CustomizationItemDetailResponse getCustomization(@Positive @PathVariable Long customizationItemId) {
         return customizationItemService.findById(customizationItemId);
+    }
+
+    @Operation(summary = "커스터마이징 아이템 장착")
+    @PostMapping("/{customizationItemId}/equip")
+    @ResponseStatus(HttpStatus.OK)
+    public void equip(@Positive @PathVariable Long customizationItemId) {
+        customizationItemService.equip(SecurityUtil.getCurrentUserId(), customizationItemId);
+    }
+
+    @Operation(summary = "커스터마이징 아이템 장착 해제")
+    @DeleteMapping("/{customizationItemId}/equip")
+    @ResponseStatus(HttpStatus.OK)
+    public void unequip(@Positive @PathVariable Long customizationItemId) {
+        customizationItemService.unequip(SecurityUtil.getCurrentUserId(), customizationItemId);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/CustomizationController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/CustomizationController.java
@@ -1,0 +1,36 @@
+package com.dnd5.timoapi.domain.customization.presentation;
+
+import com.dnd5.timoapi.domain.customization.application.service.CustomizationItemService;
+import com.dnd5.timoapi.domain.customization.presentation.response.CustomizationItemDetailResponse;
+import com.dnd5.timoapi.domain.customization.presentation.response.CustomizationItemResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/customizations")
+@RequiredArgsConstructor
+@Validated
+public class CustomizationController {
+
+    private final CustomizationItemService customizationItemService;
+
+    @Operation(summary = "커스터마이징 아이템 목록 조회")
+    @GetMapping
+    public List<CustomizationItemResponse> getCustomizations() {
+        return customizationItemService.findAll();
+    }
+
+    @Operation(summary = "커스터마이징 아이템 단건 조회")
+    @GetMapping("/{customizationItemId}")
+    public CustomizationItemDetailResponse getCustomization(@Positive @PathVariable Long customizationItemId) {
+        return customizationItemService.findById(customizationItemId);
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemCreateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemCreateRequest.java
@@ -1,0 +1,26 @@
+package com.dnd5.timoapi.domain.customization.presentation.request;
+
+import com.dnd5.timoapi.domain.customization.domain.model.CustomizationItem;
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationItemType;
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationUnlockConditionType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record CustomizationItemCreateRequest(
+        @NotBlank
+        String name,
+        @NotNull
+        CustomizationItemType type,
+        String description,
+        @NotNull
+        CustomizationUnlockConditionType unlockConditionType,
+        @NotNull
+        @Positive
+        Integer unlockConditionCount,
+        String image
+) {
+    public CustomizationItem toModel() {
+        return CustomizationItem.create(name, type, description, unlockConditionType, unlockConditionCount, image);
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemUpdateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.dnd5.timoapi.domain.customization.presentation.request;
+
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationItemType;
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationUnlockConditionType;
+import jakarta.validation.constraints.Positive;
+
+public record CustomizationItemUpdateRequest(
+        String name,
+        CustomizationItemType type,
+        String description,
+        CustomizationUnlockConditionType unlockConditionType,
+        @Positive
+        Integer unlockConditionCount,
+        String image
+) {
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/CustomizationItemDetailResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/CustomizationItemDetailResponse.java
@@ -1,0 +1,27 @@
+package com.dnd5.timoapi.domain.customization.presentation.response;
+
+import com.dnd5.timoapi.domain.customization.domain.model.CustomizationItem;
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationItemType;
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationUnlockConditionType;
+
+public record CustomizationItemDetailResponse(
+        Long id,
+        String name,
+        CustomizationItemType type,
+        String description,
+        CustomizationUnlockConditionType unlockConditionType,
+        Integer unlockConditionCount,
+        String image
+) {
+    public static CustomizationItemDetailResponse from(CustomizationItem model) {
+        return new CustomizationItemDetailResponse(
+                model.id(),
+                model.name(),
+                model.type(),
+                model.description(),
+                model.unlockConditionType(),
+                model.unlockConditionCount(),
+                model.image()
+        );
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/CustomizationItemResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/CustomizationItemResponse.java
@@ -1,0 +1,16 @@
+package com.dnd5.timoapi.domain.customization.presentation.response;
+
+import com.dnd5.timoapi.domain.customization.domain.model.CustomizationItem;
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationItemType;
+
+public record CustomizationItemResponse(
+        Long id,
+        String name,
+        CustomizationItemType type,
+        boolean isUnlocked,
+        boolean isEquipped
+) {
+    public static CustomizationItemResponse from(CustomizationItem model, boolean isUnlocked, boolean isEquipped) {
+        return new CustomizationItemResponse(model.id(), model.name(), model.type(), isUnlocked, isEquipped);
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/EquippedCustomizationResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/EquippedCustomizationResponse.java
@@ -1,0 +1,15 @@
+package com.dnd5.timoapi.domain.customization.presentation.response;
+
+import com.dnd5.timoapi.domain.customization.domain.model.CustomizationItem;
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationItemType;
+
+public record EquippedCustomizationResponse(
+        Long id,
+        String name,
+        CustomizationItemType type,
+        String image
+) {
+    public static EquippedCustomizationResponse from(CustomizationItem model) {
+        return new EquippedCustomizationResponse(model.id(), model.name(), model.type(), model.image());
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/UnlockedCustomizationItemResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/UnlockedCustomizationItemResponse.java
@@ -1,0 +1,17 @@
+package com.dnd5.timoapi.domain.customization.presentation.response;
+
+import com.dnd5.timoapi.domain.customization.domain.model.CustomizationItem;
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationItemType;
+
+public record UnlockedCustomizationItemResponse(
+        Long id,
+        String name,
+        CustomizationItemType type,
+        String description,
+        String image
+) {
+    public static UnlockedCustomizationItemResponse from(CustomizationItem model) {
+        return new UnlockedCustomizationItemResponse(
+                model.id(), model.name(), model.type(), model.description(), model.image());
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/scheduler/ReflectionScheduler.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/scheduler/ReflectionScheduler.java
@@ -1,5 +1,6 @@
 package com.dnd5.timoapi.domain.reflection.application.scheduler;
 
+import com.dnd5.timoapi.domain.customization.application.service.CustomizationItemService;
 import com.dnd5.timoapi.domain.reflection.application.support.TodayQuestionResolver;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionQuestionEntity;
@@ -8,6 +9,7 @@ import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionQuestionRe
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
 import com.dnd5.timoapi.domain.reflection.domain.repository.UserReflectionQuestionOrderRepository;
 import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
 import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
 import java.time.LocalDate;
 import java.util.List;
@@ -30,6 +32,7 @@ public class ReflectionScheduler {
     private final UserReflectionQuestionOrderRepository userReflectionQuestionOrderRepository;
     private final UserRepository userRepository;
     private final TodayQuestionResolver todayQuestionResolver;
+    private final CustomizationItemService customizationItemService;
 
     @Scheduled(cron = "0 0 0 * * *")
     @Transactional
@@ -51,7 +54,14 @@ public class ReflectionScheduler {
         Set<Long> activeUserIds = yesterdayReflections.stream()
                 .map(ReflectionEntity::getUserId)
                 .collect(Collectors.toSet());
+
+        List<Long> resetUserIds = userRepository.findAllByStreakDaysGreaterThanAndDeletedAtIsNull(0).stream()
+                .map(UserEntity::getId)
+                .filter(userId -> !activeUserIds.contains(userId))
+                .toList();
+
         userRepository.resetStreakForInactiveUsers(activeUserIds);
+        customizationItemService.revokeStreakUnlocksFor(resetUserIds);
 
         log.info("Reflection scheduler completed");
     }

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionService.java
@@ -20,6 +20,7 @@ import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionFeedba
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionQuestionDetailResponse;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionQuestionResponse;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionResponse;
+import com.dnd5.timoapi.domain.customization.application.service.CustomizationItemService;
 import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
 import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
@@ -48,6 +49,7 @@ public class ReflectionService {
     private final TodayQuestionCacheService todayQuestionCacheService;
     private final UserRepository userRepository;
     private final UserReflectionQuestionOrderRepository userReflectionQuestionOrderRepository;
+    private final CustomizationItemService customizationItemService;
 
     public ReflectionCreateResponse create(ReflectionCreateRequest request) {
         Long userId = SecurityUtil.getCurrentUserId();
@@ -76,6 +78,8 @@ public class ReflectionService {
         boolean wroteYesterday = isWroteYesterday(userId);
         userEntity.updateStreak(wroteYesterday);
         userEntity.incrementTotalDays();
+
+        customizationItemService.unlockEligibleItems(userId);
 
         return new ReflectionCreateResponse(saved.getId());
     }

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionService.java
@@ -21,6 +21,7 @@ import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionQuesti
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionQuestionResponse;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionResponse;
 import com.dnd5.timoapi.domain.customization.application.service.CustomizationItemService;
+import com.dnd5.timoapi.domain.customization.presentation.response.UnlockedCustomizationItemResponse;
 import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
 import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
@@ -79,9 +80,10 @@ public class ReflectionService {
         userEntity.updateStreak(wroteYesterday);
         userEntity.incrementTotalDays();
 
-        customizationItemService.unlockEligibleItems(userId);
+        List<UnlockedCustomizationItemResponse> unlockedCustomizations =
+                customizationItemService.unlockEligibleItems(userId);
 
-        return new ReflectionCreateResponse(saved.getId());
+        return new ReflectionCreateResponse(saved.getId(), unlockedCustomizations);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/presentation/response/ReflectionCreateResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/presentation/response/ReflectionCreateResponse.java
@@ -1,7 +1,12 @@
 package com.dnd5.timoapi.domain.reflection.presentation.response;
 
+import com.dnd5.timoapi.domain.customization.presentation.response.UnlockedCustomizationItemResponse;
+
+import java.util.List;
+
 public record ReflectionCreateResponse(
-        Long id
+        Long id,
+        List<UnlockedCustomizationItemResponse> unlockedCustomizations
 ) {
 
 }

--- a/src/main/java/com/dnd5/timoapi/domain/user/application/service/UserService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/application/service/UserService.java
@@ -1,6 +1,8 @@
 package com.dnd5.timoapi.domain.user.application.service;
 
 import com.dnd5.timoapi.domain.auth.domain.repository.RefreshTokenRepository;
+import com.dnd5.timoapi.domain.customization.application.service.CustomizationItemService;
+import com.dnd5.timoapi.domain.customization.presentation.response.EquippedCustomizationResponse;
 import com.dnd5.timoapi.domain.user.application.service.UserTestRecordService;
 import com.dnd5.timoapi.domain.user.domain.entity.UserTestRecordEntity;
 import com.dnd5.timoapi.domain.user.domain.repository.UserTestRecordRepository;
@@ -26,11 +28,14 @@ public class UserService {
     private final RefreshTokenRepository refreshTokenRepository;
 
     private final UserTestRecordService userTestRecordService;
+    private final CustomizationItemService customizationItemService;
 
     @Transactional(readOnly = true)
     public UserResponse getMe() {
         UserEntity user = getCurrentUserEntity();
-        return UserResponse.from(user.toModel());
+        List<EquippedCustomizationResponse> equippedCustomizations =
+                customizationItemService.findEquippedItems(user.getId());
+        return UserResponse.from(user.toModel(), equippedCustomizations);
     }
 
     public void updateMe(UpdateMeRequest request) {

--- a/src/main/java/com/dnd5/timoapi/domain/user/presentation/response/UserResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/presentation/response/UserResponse.java
@@ -1,9 +1,11 @@
 package com.dnd5.timoapi.domain.user.presentation.response;
 
+import com.dnd5.timoapi.domain.customization.presentation.response.EquippedCustomizationResponse;
 import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import com.dnd5.timoapi.domain.user.domain.model.User;
 import com.dnd5.timoapi.domain.user.domain.model.enums.OAuthProvider;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record UserResponse(
         Long id,
@@ -13,9 +15,10 @@ public record UserResponse(
         ZtpiCategory category,
         Boolean isOnboarded,
         Integer streakDays,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        List<EquippedCustomizationResponse> equippedCustomizations
 ) {
-    public static UserResponse from(User model) {
+    public static UserResponse from(User model, List<EquippedCustomizationResponse> equippedCustomizations) {
         return new UserResponse(
                 model.id(),
                 model.nickname(),
@@ -24,7 +27,8 @@ public record UserResponse(
                 model.category(),
                 model.isOnboarded(),
                 model.streakDays(),
-                model.createdAt()
+                model.createdAt(),
+                equippedCustomizations
         );
     }
 }

--- a/src/main/java/com/dnd5/timoapi/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/dnd5/timoapi/global/security/config/SecurityConfig.java
@@ -98,6 +98,9 @@ public class SecurityConfig {
                         // 그룹
                         .requestMatchers("/groups/**").authenticated()
 
+                        // 커스터마이징
+                        .requestMatchers("/customizations/**").authenticated()
+
                         // 이미지 업로드
                         .requestMatchers(HttpMethod.POST, "/images").authenticated()
 

--- a/src/test/java/com/dnd5/timoapi/domain/reflection/application/scheduler/ReflectionSchedulerTest.java
+++ b/src/test/java/com/dnd5/timoapi/domain/reflection/application/scheduler/ReflectionSchedulerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.dnd5.timoapi.domain.customization.application.service.CustomizationItemService;
 import com.dnd5.timoapi.domain.reflection.application.support.TodayQuestionResolver;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionQuestionEntity;
@@ -45,6 +46,9 @@ class ReflectionSchedulerTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private CustomizationItemService customizationItemService;
 
     @Test
     void processYesterdayReflections_탈퇴유저_제외조회_사용() {


### PR DESCRIPTION
## What is this PR? :mag:
- customization 도메인 신규 추가 — 캐릭터 커스터마이징 아이템(테마/장식) 관리 기능
- 커스터마이징 아이템 관련 API 7개 구현 (CRUD/조회/장착)
- 회고 작성 시 총 횟수(TOTAL_COUNT)/연속 횟수(STREAK_COUNT) 조건에 따른 자동 해금
- 자정 배치에서 streak 리셋 시 STREAK_COUNT 아이템 자동 재잠금(장착 중이면 해제까지) 연동
- GET /users/me 응답에 장착 중인 커스터마이징 아이템 목록(equippedCustomizations) 추가
- 신규 해금된 아이템은 POST /reflections 응답에 바로 포함 (별도 조회 API 없이 프론트가 즉시 알림/애니메이션 표시 가능)                                                                                       

## Changes :memo:
- customization_items(아이템 정의) / customization_user_items(유저별 해금·장착 상태) 2개 테이블 구조 설계 및 추가
- unlockConditionType(TOTAL_COUNT/STREAK_COUNT) + unlockConditionCount 에서 해금 조건 설정
- 회고 작성 직후 ReflectionService.create()에서 커스터마이징 아이템 해금 동기 호출
- ReflectionScheduler(자정 배치)에서 streak가 끊기는 유저 대상 커스터마이징 아이템 재잠금 처리

## Screenshot  :camera:



---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customization item management (themes/decorations) with unlock rules and images, including admin create/update/delete endpoints.
  * Users can list items, view details, equip/unequip, and see equipped customizations in their profile.
  * Creating a reflection now returns newly unlocked customizations.
* **Bug Fixes**
  * Prevents equipping multiple themes simultaneously.
  * When streaks reset, associated customization unlocks are revoked and equipment is cleared.
* **Chores**
  * Secured customization endpoints with authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->