### PR TITLE
feat/customization-recently-unlocked

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
@@ -183,6 +183,26 @@ public class CustomizationItemService {
         return newlyUnlocked;
     }
 
+    @Transactional(readOnly = true)
+    public List<UnlockedCustomizationItemResponse> findRecentlyUnlockedItems(Long userId) {
+        UserEntity user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        List<Long> unlockedItemIds = customizationUserItemRepository
+                .findAllByUserIdAndIsUnlockedTrueAndDeletedAtIsNull(userId).stream()
+                .map(CustomizationUserItemEntity::getCustomizationItemId)
+                .toList();
+
+        if (unlockedItemIds.isEmpty()) {
+            return List.of();
+        }
+
+        return customizationItemRepository.findAllById(unlockedItemIds).stream()
+                .filter(item -> isUnlockConditionJustMet(item, user))
+                .map(item -> UnlockedCustomizationItemResponse.from(item.toModel()))
+                .toList();
+    }
+
     public void revokeStreakUnlocksFor(List<Long> userIds) {
         if (userIds.isEmpty()) {
             return;
@@ -211,6 +231,13 @@ public class CustomizationItemService {
         return switch (item.getUnlockConditionType()) {
             case TOTAL_COUNT -> item.getUnlockConditionCount() <= user.getTotalDays();
             case STREAK_COUNT -> item.getUnlockConditionCount() <= user.getStreakDays();
+        };
+    }
+
+    private boolean isUnlockConditionJustMet(CustomizationItemEntity item, UserEntity user) {
+        return switch (item.getUnlockConditionType()) {
+            case TOTAL_COUNT -> item.getUnlockConditionCount().equals(user.getTotalDays());
+            case STREAK_COUNT -> item.getUnlockConditionCount().equals(user.getStreakDays());
         };
     }
 

--- a/src/main/java/com/dnd5/timoapi/domain/customization/domain/repository/CustomizationUserItemRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/domain/repository/CustomizationUserItemRepository.java
@@ -16,6 +16,8 @@ public interface CustomizationUserItemRepository extends JpaRepository<Customiza
 
     List<CustomizationUserItemEntity> findAllByUserIdAndIsEquippedTrueAndDeletedAtIsNull(Long userId);
 
+    List<CustomizationUserItemEntity> findAllByUserIdAndIsUnlockedTrueAndDeletedAtIsNull(Long userId);
+
     List<CustomizationUserItemEntity> findAllByUserIdInAndCustomizationItemIdInAndIsUnlockedTrueAndDeletedAtIsNull(
             Collection<Long> userIds, Collection<Long> customizationItemIds);
 }

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/CustomizationController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/CustomizationController.java
@@ -3,6 +3,7 @@ package com.dnd5.timoapi.domain.customization.presentation;
 import com.dnd5.timoapi.domain.customization.application.service.CustomizationItemService;
 import com.dnd5.timoapi.domain.customization.presentation.response.CustomizationItemDetailResponse;
 import com.dnd5.timoapi.domain.customization.presentation.response.CustomizationItemResponse;
+import com.dnd5.timoapi.domain.customization.presentation.response.UnlockedCustomizationItemResponse;
 import com.dnd5.timoapi.global.security.context.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.constraints.Positive;
@@ -37,6 +38,12 @@ public class CustomizationController {
     @GetMapping("/{customizationItemId}")
     public CustomizationItemDetailResponse getCustomization(@Positive @PathVariable Long customizationItemId) {
         return customizationItemService.findById(customizationItemId);
+    }
+
+    @Operation(summary = "가장 최근 활동으로 해금된 커스터마이징 아이템 조회")
+    @GetMapping("/recently-unlocked")
+    public List<UnlockedCustomizationItemResponse> getRecentlyUnlocked() {
+        return customizationItemService.findRecentlyUnlockedItems(SecurityUtil.getCurrentUserId());
     }
 
     @Operation(summary = "커스터마이징 아이템 장착")

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/UnlockedCustomizationItemResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/UnlockedCustomizationItemResponse.java
@@ -2,16 +2,26 @@ package com.dnd5.timoapi.domain.customization.presentation.response;
 
 import com.dnd5.timoapi.domain.customization.domain.model.CustomizationItem;
 import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationItemType;
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationUnlockConditionType;
 
 public record UnlockedCustomizationItemResponse(
         Long id,
         String name,
         CustomizationItemType type,
         String description,
+        CustomizationUnlockConditionType unlockConditionType,
+        Integer unlockConditionCount,
         String image
 ) {
     public static UnlockedCustomizationItemResponse from(CustomizationItem model) {
         return new UnlockedCustomizationItemResponse(
-                model.id(), model.name(), model.type(), model.description(), model.image());
+                model.id(),
+                model.name(),
+                model.type(),
+                model.description(),
+                model.unlockConditionType(),
+                model.unlockConditionCount(),
+                model.image()
+        );
     }
 }


### PR DESCRIPTION
## What is this PR? :mag:
- 사용자가 회고 후 버튼을 눌러 요청할 수 있는 획득한 아이템 확인 API를 추가

## Changes :memo:
- GET /customizations/recently-unlocked로 호출 가능
- 가장 최근의 회고로 인해 획득한(해금된) 커스터마이징 아이템이 있다면 아이템 정보를 배열 응답으로 반환, 없는 경우 빈 배열을 반환
- POST /reflections 응답의 unlockedCustomizations 속성값과 같은 배열을 응답으로 반환

---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to retrieve customization items that were recently unlocked.
  * Recently unlocked items are identified when users newly meet their unlock requirements.
  * Responses now include unlock condition type and required count details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->