### PR TITLE
fix/statistics

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/statistics/application/service/StatisticsService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/statistics/application/service/StatisticsService.java
@@ -41,6 +41,7 @@ public class StatisticsService {
         List<ReflectionFeedbackEntity> feedbacks = reflectionFeedbackRepository
                 .findCompletedByUserIdOrderByCreatedAt(userId);
         Map<ZtpiCategory, List<ReflectionFeedbackEntity>> feedbacksByCategory = feedbacks.stream()
+                .filter(fb -> fb.getCategory() != null)
                 .collect(Collectors.groupingBy(ReflectionFeedbackEntity::getCategory));
 
         List<StatisticsCategoryResponse> categories = Arrays.stream(ZtpiCategory.values())
@@ -57,13 +58,15 @@ public class StatisticsService {
                     }
 
                     List<ReflectionFeedbackEntity> categoryFeedbacks = feedbacksByCategory.getOrDefault(category, List.of());
-                    categoryFeedbacks.forEach(fb ->
-                            dataPoints.add(new StatisticsScoreResponse(
-                                    fb.getAfterScore(),
-                                    fb.getCreatedAt(),
-                                    "REFLECTION"
-                            ))
-                    );
+                    categoryFeedbacks.stream()
+                            .filter(fb -> fb.getAfterScore() != null)
+                            .forEach(fb ->
+                                    dataPoints.add(new StatisticsScoreResponse(
+                                            fb.getAfterScore(),
+                                            fb.getCreatedAt(),
+                                            "REFLECTION"
+                                    ))
+                            );
 
                     ReflectionFeedbackEntity latestFeedback = categoryFeedbacks.isEmpty()
                             ? null : categoryFeedbacks.get(categoryFeedbacks.size() - 1);
@@ -105,13 +108,15 @@ public class StatisticsService {
         List<ReflectionFeedbackEntity> feedbacks = reflectionFeedbackRepository
                 .findCompletedByUserIdAndCategoryOrderByCreatedAt(userId, category);
 
-        feedbacks.forEach(fb -> dataPoints.add(new StatisticsScoreDetailResponse(
-                fb.getAfterScore(),
-                fb.getCreatedAt(),
-                "REFLECTION",
-                fb.getChangedScore(),
-                fb.getIsIncreased()
-        )));
+        feedbacks.stream()
+                .filter(fb -> fb.getAfterScore() != null)
+                .forEach(fb -> dataPoints.add(new StatisticsScoreDetailResponse(
+                        fb.getAfterScore(),
+                        fb.getCreatedAt(),
+                        "REFLECTION",
+                        fb.getChangedScore(),
+                        fb.getIsIncreased()
+                )));
 
         ReflectionFeedbackEntity latestFeedback = feedbacks.isEmpty() ? null : feedbacks.get(feedbacks.size() - 1);
         ProximityInfo proximity = calculateProximity(latestFeedback, category.getIdealScore());


### PR DESCRIPTION
## What is this PR? :mag:
통계 조회 시 legacy 회고 피드백 데이터로 인한 NPE 방지

## Changes :memo:
- statistics@test.com 외 계정으로 `/statistics` 조회 시 500 에러가 발생하는 문제 수정
- `reflection_feedbacks`의 `category`, `afterScore` 등의 필드가 2026-05-25에 뒤늦게 추가되면서, 그 이전에 COMPLETED된 legacy 피드백 데이터는 해당 필드가 NULL로 남아있었음
    - `category`가 NULL인 완료 피드백 → `Collectors.groupingBy`에서 NullPointerException
    - `afterScore`가 NULL인 완료 피드백 → `StatisticsScoreResponse.score`(primitive `double`) auto-unboxing 과정에서 NullPointerException
- `StatisticsService`의 `getStatistics()` / `getCategoryStatistics()` 양쪽에 null 방어 필터 추가
    - `category == null`인 피드백은 카테고리 그룹핑에서 제외
    - `afterScore == null`인 피드백은 그래프 데이터포인트에서만 제외 (근접도 계산은 기존 null 체크로 이미 안전)
- 서버 DB의 legacy null-category 데이터는 별도로 백필/정리 완료 (코드 변경과 무관한 데이터 작업)

## Screenshot  :camera:



---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved statistics accuracy by excluding reflection feedback with missing categories.
  * Prevented incomplete reflection entries from being included when their score is unavailable.
  * Applied consistent filtering across overall and category-specific statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->