### PR TITLE
fix/customization

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
@@ -20,6 +20,7 @@ import com.dnd5.timoapi.domain.customization.presentation.response.Customization
 import com.dnd5.timoapi.domain.customization.presentation.response.EquippedCustomizationResponse;
 import com.dnd5.timoapi.domain.customization.presentation.response.UnlockedCustomizationItemResponse;
 import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+import com.dnd5.timoapi.domain.test.domain.repository.TimePerspectiveCategoryRepository;
 import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
 import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
 import com.dnd5.timoapi.domain.user.exception.UserErrorCode;
@@ -31,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -46,6 +48,7 @@ public class CustomizationItemService {
     private final CustomizationItemImageRepository customizationItemImageRepository;
     private final CustomizationUserItemRepository customizationUserItemRepository;
     private final UserRepository userRepository;
+    private final TimePerspectiveCategoryRepository timePerspectiveCategoryRepository;
 
     @Transactional(readOnly = true)
     public List<CustomizationItemResponse> findAll() {
@@ -58,8 +61,7 @@ public class CustomizationItemService {
                 .collect(Collectors.toMap(CustomizationUserItemEntity::getCustomizationItemId, Function.identity()));
 
         List<CustomizationItemEntity> items = customizationItemRepository.findAllByDeletedAtIsNull();
-        Map<Long, CustomizationItemImage> imagesByItemId = resolveImages(
-                items.stream().map(CustomizationItemEntity::getId).toList(), user.getCategory());
+        Map<Long, CustomizationItemImage> imagesByItemId = resolveImages(items, user.getCategory());
 
         return items.stream()
                 .map(itemEntity -> {
@@ -93,7 +95,7 @@ public class CustomizationItemService {
 
         Map<Long, CustomizationItemEntity> itemsById = customizationItemRepository.findAllById(itemIds).stream()
                 .collect(Collectors.toMap(CustomizationItemEntity::getId, Function.identity()));
-        Map<Long, CustomizationItemImage> imagesByItemId = resolveImages(itemIds, user.getCategory());
+        Map<Long, CustomizationItemImage> imagesByItemId = resolveImages(itemsById.values(), user.getCategory());
 
         return equippedUserItems.stream()
                 .map(userItem -> itemsById.get(userItem.getCustomizationItemId()))
@@ -113,7 +115,7 @@ public class CustomizationItemService {
         UserEntity user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
         CustomizationItemEntity entity = getCustomizationItemEntity(customizationItemId);
-        CustomizationItemImage image = resolveImage(customizationItemId, user.getCategory());
+        CustomizationItemImage image = resolveImage(entity, user.getCategory());
         return CustomizationItemDetailResponse.from(
                 entity.toModel(),
                 image != null ? image.image() : null,
@@ -233,7 +235,7 @@ public class CustomizationItemService {
                 userItem.unlock();
             }
 
-            CustomizationItemImage image = resolveImage(item.getId(), user.getCategory());
+            CustomizationItemImage image = resolveImage(item, user.getCategory());
             newlyUnlocked.add(UnlockedCustomizationItemResponse.from(
                     item.toModel(),
                     image != null ? image.image() : null,
@@ -261,8 +263,7 @@ public class CustomizationItemService {
                 .filter(item -> isUnlockConditionJustMet(item, user))
                 .toList();
 
-        Map<Long, CustomizationItemImage> imagesByItemId = resolveImages(
-                justMetItems.stream().map(CustomizationItemEntity::getId).toList(), user.getCategory());
+        Map<Long, CustomizationItemImage> imagesByItemId = resolveImages(justMetItems, user.getCategory());
 
         return justMetItems.stream()
                 .map(item -> {
@@ -313,23 +314,64 @@ public class CustomizationItemService {
         };
     }
 
-    private CustomizationItemImage resolveImage(Long customizationItemId, ZtpiCategory category) {
+    private static final String CHARACTER_PET_ITEM_NAME = "나의 캐릭터 펫";
+
+    private boolean usesCharacterImage(CustomizationItemEntity item) {
+        return CHARACTER_PET_ITEM_NAME.equals(item.getName());
+    }
+
+    private CustomizationItemImage resolveImage(CustomizationItemEntity item, ZtpiCategory category) {
         if (category == null) {
             return null;
         }
+        if (usesCharacterImage(item)) {
+            return resolveCharacterImage(item.getId(), category);
+        }
         return customizationItemImageRepository
-                .findByCustomizationItemIdAndCategoryAndDeletedAtIsNull(customizationItemId, category)
+                .findByCustomizationItemIdAndCategoryAndDeletedAtIsNull(item.getId(), category)
                 .map(CustomizationItemImageEntity::toModel)
                 .orElse(null);
     }
 
-    private Map<Long, CustomizationItemImage> resolveImages(Collection<Long> customizationItemIds, ZtpiCategory category) {
-        if (category == null || customizationItemIds.isEmpty()) {
+    private Map<Long, CustomizationItemImage> resolveImages(Collection<CustomizationItemEntity> items, ZtpiCategory category) {
+        if (category == null || items.isEmpty()) {
             return Map.of();
         }
-        return customizationItemImageRepository
-                .findAllByCustomizationItemIdInAndCategoryAndDeletedAtIsNull(customizationItemIds, category).stream()
-                .collect(Collectors.toMap(CustomizationItemImageEntity::getCustomizationItemId, CustomizationItemImageEntity::toModel));
+
+        Map<Long, CustomizationItemImage> result = new HashMap<>();
+
+        List<Long> uploadedImageItemIds = items.stream()
+                .filter(item -> !usesCharacterImage(item))
+                .map(CustomizationItemEntity::getId)
+                .toList();
+        if (!uploadedImageItemIds.isEmpty()) {
+            customizationItemImageRepository
+                    .findAllByCustomizationItemIdInAndCategoryAndDeletedAtIsNull(uploadedImageItemIds, category)
+                    .forEach(entity -> result.put(entity.getCustomizationItemId(), entity.toModel()));
+        }
+
+        List<CustomizationItemEntity> characterImageItems = items.stream()
+                .filter(this::usesCharacterImage)
+                .toList();
+        if (!characterImageItems.isEmpty()) {
+            CustomizationItemImage characterImage = resolveCharacterImage(null, category);
+            if (characterImage != null) {
+                characterImageItems.forEach(item -> result.put(item.getId(), characterImage));
+            }
+        }
+
+        return result;
+    }
+
+    private CustomizationItemImage resolveCharacterImage(Long customizationItemId, ZtpiCategory category) {
+        return timePerspectiveCategoryRepository
+                .findAllByEnglishNameAndDeletedAtIsNull(category.name())
+                .stream()
+                .findFirst()
+                .map(tpc -> new CustomizationItemImage(
+                        null, customizationItemId, category, tpc.getImage(), null,
+                        tpc.getCreatedAt(), tpc.getUpdatedAt(), null))
+                .orElse(null);
     }
 
     private CustomizationItemEntity getCustomizationItemEntity(Long customizationItemId) {

--- a/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
@@ -13,7 +13,7 @@ import com.dnd5.timoapi.domain.customization.domain.repository.CustomizationItem
 import com.dnd5.timoapi.domain.customization.domain.repository.CustomizationUserItemRepository;
 import com.dnd5.timoapi.domain.customization.exception.CustomizationItemErrorCode;
 import com.dnd5.timoapi.domain.customization.presentation.request.CustomizationItemCreateRequest;
-import com.dnd5.timoapi.domain.customization.presentation.request.CustomizationItemImageRequest;
+import com.dnd5.timoapi.domain.customization.presentation.request.CustomizationItemImageCreateRequest;
 import com.dnd5.timoapi.domain.customization.presentation.request.CustomizationItemUpdateRequest;
 import com.dnd5.timoapi.domain.customization.presentation.response.CustomizationItemDetailResponse;
 import com.dnd5.timoapi.domain.customization.presentation.response.CustomizationItemResponse;
@@ -146,7 +146,7 @@ public class CustomizationItemService {
         );
 
         if (request.images() != null) {
-            for (CustomizationItemImageRequest imageRequest : request.images()) {
+            for (CustomizationItemImageCreateRequest imageRequest : request.images()) {
                 CustomizationItemImageEntity existing = customizationItemImageRepository
                         .findByCustomizationItemIdAndCategoryAndDeletedAtIsNull(customizationItemId, imageRequest.category())
                         .orElse(null);

--- a/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
@@ -1,20 +1,25 @@
 package com.dnd5.timoapi.domain.customization.application.service;
 
 import com.dnd5.timoapi.domain.customization.domain.entity.CustomizationItemEntity;
+import com.dnd5.timoapi.domain.customization.domain.entity.CustomizationItemImageEntity;
 import com.dnd5.timoapi.domain.customization.domain.entity.CustomizationUserItemEntity;
 import com.dnd5.timoapi.domain.customization.domain.model.CustomizationItem;
+import com.dnd5.timoapi.domain.customization.domain.model.CustomizationItemImage;
 import com.dnd5.timoapi.domain.customization.domain.model.CustomizationUserItem;
 import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationItemType;
 import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationUnlockConditionType;
+import com.dnd5.timoapi.domain.customization.domain.repository.CustomizationItemImageRepository;
 import com.dnd5.timoapi.domain.customization.domain.repository.CustomizationItemRepository;
 import com.dnd5.timoapi.domain.customization.domain.repository.CustomizationUserItemRepository;
 import com.dnd5.timoapi.domain.customization.exception.CustomizationItemErrorCode;
 import com.dnd5.timoapi.domain.customization.presentation.request.CustomizationItemCreateRequest;
+import com.dnd5.timoapi.domain.customization.presentation.request.CustomizationItemImageRequest;
 import com.dnd5.timoapi.domain.customization.presentation.request.CustomizationItemUpdateRequest;
 import com.dnd5.timoapi.domain.customization.presentation.response.CustomizationItemDetailResponse;
 import com.dnd5.timoapi.domain.customization.presentation.response.CustomizationItemResponse;
 import com.dnd5.timoapi.domain.customization.presentation.response.EquippedCustomizationResponse;
 import com.dnd5.timoapi.domain.customization.presentation.response.UnlockedCustomizationItemResponse;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
 import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
 import com.dnd5.timoapi.domain.user.exception.UserErrorCode;
@@ -25,6 +30,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -37,29 +43,43 @@ import java.util.stream.Collectors;
 public class CustomizationItemService {
 
     private final CustomizationItemRepository customizationItemRepository;
+    private final CustomizationItemImageRepository customizationItemImageRepository;
     private final CustomizationUserItemRepository customizationUserItemRepository;
     private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public List<CustomizationItemResponse> findAll() {
         Long userId = SecurityUtil.getCurrentUserId();
+        UserEntity user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
         Map<Long, CustomizationUserItemEntity> userItemsByItemId = customizationUserItemRepository
                 .findAllByUserIdAndDeletedAtIsNull(userId).stream()
                 .collect(Collectors.toMap(CustomizationUserItemEntity::getCustomizationItemId, Function.identity()));
 
-        return customizationItemRepository.findAllByDeletedAtIsNull().stream()
+        List<CustomizationItemEntity> items = customizationItemRepository.findAllByDeletedAtIsNull();
+        Map<Long, CustomizationItemImage> imagesByItemId = resolveImages(
+                items.stream().map(CustomizationItemEntity::getId).toList(), user.getCategory());
+
+        return items.stream()
                 .map(itemEntity -> {
                     CustomizationUserItemEntity userItem = userItemsByItemId.get(itemEntity.getId());
                     boolean isUnlocked = userItem != null && userItem.isUnlocked();
                     boolean isEquipped = userItem != null && userItem.isEquipped();
-                    return CustomizationItemResponse.from(itemEntity.toModel(), isUnlocked, isEquipped);
+                    CustomizationItemImage image = imagesByItemId.get(itemEntity.getId());
+                    return CustomizationItemResponse.from(
+                            itemEntity.toModel(), isUnlocked, isEquipped,
+                            image != null ? image.image() : null,
+                            image != null ? image.imageWithoutBackground() : null);
                 })
                 .toList();
     }
 
     @Transactional(readOnly = true)
     public List<EquippedCustomizationResponse> findEquippedItems(Long userId) {
+        UserEntity user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
         List<CustomizationUserItemEntity> equippedUserItems = customizationUserItemRepository
                 .findAllByUserIdAndIsEquippedTrueAndDeletedAtIsNull(userId);
 
@@ -73,23 +93,44 @@ public class CustomizationItemService {
 
         Map<Long, CustomizationItemEntity> itemsById = customizationItemRepository.findAllById(itemIds).stream()
                 .collect(Collectors.toMap(CustomizationItemEntity::getId, Function.identity()));
+        Map<Long, CustomizationItemImage> imagesByItemId = resolveImages(itemIds, user.getCategory());
 
         return equippedUserItems.stream()
                 .map(userItem -> itemsById.get(userItem.getCustomizationItemId()))
                 .filter(item -> item != null)
-                .map(item -> EquippedCustomizationResponse.from(item.toModel()))
+                .map(item -> {
+                    CustomizationItemImage image = imagesByItemId.get(item.getId());
+                    return EquippedCustomizationResponse.from(
+                            item.toModel(),
+                            image != null ? image.image() : null,
+                            image != null ? image.imageWithoutBackground() : null);
+                })
                 .toList();
     }
 
     @Transactional(readOnly = true)
-    public CustomizationItemDetailResponse findById(Long customizationItemId) {
+    public CustomizationItemDetailResponse findById(Long userId, Long customizationItemId) {
+        UserEntity user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
         CustomizationItemEntity entity = getCustomizationItemEntity(customizationItemId);
-        return CustomizationItemDetailResponse.from(entity.toModel());
+        CustomizationItemImage image = resolveImage(customizationItemId, user.getCategory());
+        return CustomizationItemDetailResponse.from(
+                entity.toModel(),
+                image != null ? image.image() : null,
+                image != null ? image.imageWithoutBackground() : null);
     }
 
     public void create(CustomizationItemCreateRequest request) {
         CustomizationItem model = request.toModel();
-        customizationItemRepository.save(CustomizationItemEntity.from(model));
+        CustomizationItemEntity savedItem = customizationItemRepository.save(CustomizationItemEntity.from(model));
+
+        List<CustomizationItemImageEntity> images = request.images().stream()
+                .map(imageRequest -> CustomizationItemImageEntity.from(
+                        CustomizationItemImage.create(
+                                savedItem.getId(), imageRequest.category(),
+                                imageRequest.image(), imageRequest.imageWithoutBackground())))
+                .toList();
+        customizationItemImageRepository.saveAll(images);
     }
 
     public void update(Long customizationItemId, CustomizationItemUpdateRequest request) {
@@ -99,9 +140,24 @@ public class CustomizationItemService {
                 request.type(),
                 request.description(),
                 request.unlockConditionType(),
-                request.unlockConditionCount(),
-                request.image()
+                request.unlockConditionCount()
         );
+
+        if (request.images() != null) {
+            for (CustomizationItemImageRequest imageRequest : request.images()) {
+                CustomizationItemImageEntity existing = customizationItemImageRepository
+                        .findByCustomizationItemIdAndCategoryAndDeletedAtIsNull(customizationItemId, imageRequest.category())
+                        .orElse(null);
+                if (existing == null) {
+                    customizationItemImageRepository.save(CustomizationItemImageEntity.from(
+                            CustomizationItemImage.create(
+                                    customizationItemId, imageRequest.category(),
+                                    imageRequest.image(), imageRequest.imageWithoutBackground())));
+                } else {
+                    existing.updateImage(imageRequest.image(), imageRequest.imageWithoutBackground());
+                }
+            }
+        }
     }
 
     public void delete(Long customizationItemId) {
@@ -177,7 +233,11 @@ public class CustomizationItemService {
                 userItem.unlock();
             }
 
-            newlyUnlocked.add(UnlockedCustomizationItemResponse.from(item.toModel()));
+            CustomizationItemImage image = resolveImage(item.getId(), user.getCategory());
+            newlyUnlocked.add(UnlockedCustomizationItemResponse.from(
+                    item.toModel(),
+                    image != null ? image.image() : null,
+                    image != null ? image.imageWithoutBackground() : null));
         }
 
         return newlyUnlocked;
@@ -197,9 +257,21 @@ public class CustomizationItemService {
             return List.of();
         }
 
-        return customizationItemRepository.findAllById(unlockedItemIds).stream()
+        List<CustomizationItemEntity> justMetItems = customizationItemRepository.findAllById(unlockedItemIds).stream()
                 .filter(item -> isUnlockConditionJustMet(item, user))
-                .map(item -> UnlockedCustomizationItemResponse.from(item.toModel()))
+                .toList();
+
+        Map<Long, CustomizationItemImage> imagesByItemId = resolveImages(
+                justMetItems.stream().map(CustomizationItemEntity::getId).toList(), user.getCategory());
+
+        return justMetItems.stream()
+                .map(item -> {
+                    CustomizationItemImage image = imagesByItemId.get(item.getId());
+                    return UnlockedCustomizationItemResponse.from(
+                            item.toModel(),
+                            image != null ? image.image() : null,
+                            image != null ? image.imageWithoutBackground() : null);
+                })
                 .toList();
     }
 
@@ -239,6 +311,25 @@ public class CustomizationItemService {
             case TOTAL_COUNT -> item.getUnlockConditionCount().equals(user.getTotalDays());
             case STREAK_COUNT -> item.getUnlockConditionCount().equals(user.getStreakDays());
         };
+    }
+
+    private CustomizationItemImage resolveImage(Long customizationItemId, ZtpiCategory category) {
+        if (category == null) {
+            return null;
+        }
+        return customizationItemImageRepository
+                .findByCustomizationItemIdAndCategoryAndDeletedAtIsNull(customizationItemId, category)
+                .map(CustomizationItemImageEntity::toModel)
+                .orElse(null);
+    }
+
+    private Map<Long, CustomizationItemImage> resolveImages(Collection<Long> customizationItemIds, ZtpiCategory category) {
+        if (category == null || customizationItemIds.isEmpty()) {
+            return Map.of();
+        }
+        return customizationItemImageRepository
+                .findAllByCustomizationItemIdInAndCategoryAndDeletedAtIsNull(customizationItemIds, category).stream()
+                .collect(Collectors.toMap(CustomizationItemImageEntity::getCustomizationItemId, CustomizationItemImageEntity::toModel));
     }
 
     private CustomizationItemEntity getCustomizationItemEntity(Long customizationItemId) {

--- a/src/main/java/com/dnd5/timoapi/domain/customization/domain/entity/CustomizationItemEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/domain/entity/CustomizationItemEntity.java
@@ -38,17 +38,13 @@ public class CustomizationItemEntity extends BaseEntity {
     @Column(nullable = false)
     private Integer unlockConditionCount;
 
-    @Column(columnDefinition = "TEXT")
-    private String image;
-
     public static CustomizationItemEntity from(CustomizationItem model) {
         return new CustomizationItemEntity(
                 model.name(),
                 model.type(),
                 model.description(),
                 model.unlockConditionType(),
-                model.unlockConditionCount(),
-                model.image()
+                model.unlockConditionCount()
         );
     }
 
@@ -60,7 +56,6 @@ public class CustomizationItemEntity extends BaseEntity {
                 getDescription(),
                 getUnlockConditionType(),
                 getUnlockConditionCount(),
-                getImage(),
                 getCreatedAt(),
                 getUpdatedAt(),
                 getDeletedAt()
@@ -72,14 +67,12 @@ public class CustomizationItemEntity extends BaseEntity {
             CustomizationItemType type,
             String description,
             CustomizationUnlockConditionType unlockConditionType,
-            Integer unlockConditionCount,
-            String image
+            Integer unlockConditionCount
     ) {
         if (name != null) this.name = name;
         if (type != null) this.type = type;
         if (description != null) this.description = description;
         if (unlockConditionType != null) this.unlockConditionType = unlockConditionType;
         if (unlockConditionCount != null) this.unlockConditionCount = unlockConditionCount;
-        if (image != null) this.image = image;
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/customization/domain/entity/CustomizationItemImageEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/domain/entity/CustomizationItemImageEntity.java
@@ -1,0 +1,62 @@
+package com.dnd5.timoapi.domain.customization.domain.entity;
+
+import com.dnd5.timoapi.domain.customization.domain.model.CustomizationItemImage;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+import com.dnd5.timoapi.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(
+        name = "customization_item_images",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"customization_item_id", "category"})
+)
+public class CustomizationItemImageEntity extends BaseEntity {
+
+    @Column(name = "customization_item_id", nullable = false)
+    private Long customizationItemId;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ZtpiCategory category;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String image;
+
+    @Column(name = "image_without_background", columnDefinition = "TEXT", nullable = false)
+    private String imageWithoutBackground;
+
+    public static CustomizationItemImageEntity from(CustomizationItemImage model) {
+        return new CustomizationItemImageEntity(
+                model.customizationItemId(), model.category(), model.image(), model.imageWithoutBackground());
+    }
+
+    public CustomizationItemImage toModel() {
+        return new CustomizationItemImage(
+                getId(),
+                getCustomizationItemId(),
+                getCategory(),
+                getImage(),
+                getImageWithoutBackground(),
+                getCreatedAt(),
+                getUpdatedAt(),
+                getDeletedAt()
+        );
+    }
+
+    public void updateImage(String image, String imageWithoutBackground) {
+        this.image = image;
+        this.imageWithoutBackground = imageWithoutBackground;
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/domain/model/CustomizationItem.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/domain/model/CustomizationItem.java
@@ -12,7 +12,6 @@ public record CustomizationItem(
         String description,
         CustomizationUnlockConditionType unlockConditionType,
         Integer unlockConditionCount,
-        String image,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         LocalDateTime deletedAt
@@ -22,9 +21,8 @@ public record CustomizationItem(
             CustomizationItemType type,
             String description,
             CustomizationUnlockConditionType unlockConditionType,
-            Integer unlockConditionCount,
-            String image
+            Integer unlockConditionCount
     ) {
-        return new CustomizationItem(null, name, type, description, unlockConditionType, unlockConditionCount, image, null, null, null);
+        return new CustomizationItem(null, name, type, description, unlockConditionType, unlockConditionCount, null, null, null);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/customization/domain/model/CustomizationItemImage.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/domain/model/CustomizationItemImage.java
@@ -1,0 +1,22 @@
+package com.dnd5.timoapi.domain.customization.domain.model;
+
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+
+import java.time.LocalDateTime;
+
+public record CustomizationItemImage(
+        Long id,
+        Long customizationItemId,
+        ZtpiCategory category,
+        String image,
+        String imageWithoutBackground,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        LocalDateTime deletedAt
+) {
+    public static CustomizationItemImage create(
+            Long customizationItemId, ZtpiCategory category, String image, String imageWithoutBackground) {
+        return new CustomizationItemImage(
+                null, customizationItemId, category, image, imageWithoutBackground, null, null, null);
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/domain/repository/CustomizationItemImageRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/domain/repository/CustomizationItemImageRepository.java
@@ -1,0 +1,20 @@
+package com.dnd5.timoapi.domain.customization.domain.repository;
+
+import com.dnd5.timoapi.domain.customization.domain.entity.CustomizationItemImageEntity;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface CustomizationItemImageRepository extends JpaRepository<CustomizationItemImageEntity, Long> {
+
+    List<CustomizationItemImageEntity> findAllByCustomizationItemIdAndDeletedAtIsNull(Long customizationItemId);
+
+    Optional<CustomizationItemImageEntity> findByCustomizationItemIdAndCategoryAndDeletedAtIsNull(
+            Long customizationItemId, ZtpiCategory category);
+
+    List<CustomizationItemImageEntity> findAllByCustomizationItemIdInAndCategoryAndDeletedAtIsNull(
+            Collection<Long> customizationItemIds, ZtpiCategory category);
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/CustomizationController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/CustomizationController.java
@@ -37,7 +37,7 @@ public class CustomizationController {
     @Operation(summary = "커스터마이징 아이템 단건 조회")
     @GetMapping("/{customizationItemId}")
     public CustomizationItemDetailResponse getCustomization(@Positive @PathVariable Long customizationItemId) {
-        return customizationItemService.findById(customizationItemId);
+        return customizationItemService.findById(SecurityUtil.getCurrentUserId(), customizationItemId);
     }
 
     @Operation(summary = "가장 최근 활동으로 해금된 커스터마이징 아이템 조회")

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemCreateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemCreateRequest.java
@@ -3,9 +3,13 @@ package com.dnd5.timoapi.domain.customization.presentation.request;
 import com.dnd5.timoapi.domain.customization.domain.model.CustomizationItem;
 import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationItemType;
 import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationUnlockConditionType;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+
+import java.util.List;
 
 public record CustomizationItemCreateRequest(
         @NotBlank
@@ -18,9 +22,11 @@ public record CustomizationItemCreateRequest(
         @NotNull
         @Positive
         Integer unlockConditionCount,
-        String image
+        @NotEmpty
+        @Valid
+        List<CustomizationItemImageRequest> images
 ) {
     public CustomizationItem toModel() {
-        return CustomizationItem.create(name, type, description, unlockConditionType, unlockConditionCount, image);
+        return CustomizationItem.create(name, type, description, unlockConditionType, unlockConditionCount);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemCreateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemCreateRequest.java
@@ -24,7 +24,7 @@ public record CustomizationItemCreateRequest(
         Integer unlockConditionCount,
         @NotEmpty
         @Valid
-        List<CustomizationItemImageRequest> images
+        List<CustomizationItemImageCreateRequest> images
 ) {
     public CustomizationItem toModel() {
         return CustomizationItem.create(name, type, description, unlockConditionType, unlockConditionCount);

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemImageCreateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemImageCreateRequest.java
@@ -4,7 +4,7 @@ import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record CustomizationItemImageRequest(
+public record CustomizationItemImageCreateRequest(
         @NotNull
         ZtpiCategory category,
         @NotBlank

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemImageRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemImageRequest.java
@@ -1,0 +1,15 @@
+package com.dnd5.timoapi.domain.customization.presentation.request;
+
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CustomizationItemImageRequest(
+        @NotNull
+        ZtpiCategory category,
+        @NotBlank
+        String image,
+        @NotBlank
+        String imageWithoutBackground
+) {
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemUpdateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemUpdateRequest.java
@@ -15,6 +15,6 @@ public record CustomizationItemUpdateRequest(
         @Positive
         Integer unlockConditionCount,
         @Valid
-        List<CustomizationItemImageRequest> images
+        List<CustomizationItemImageCreateRequest> images
 ) {
 }

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemUpdateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemUpdateRequest.java
@@ -2,7 +2,10 @@ package com.dnd5.timoapi.domain.customization.presentation.request;
 
 import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationItemType;
 import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationUnlockConditionType;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
+
+import java.util.List;
 
 public record CustomizationItemUpdateRequest(
         String name,
@@ -11,6 +14,7 @@ public record CustomizationItemUpdateRequest(
         CustomizationUnlockConditionType unlockConditionType,
         @Positive
         Integer unlockConditionCount,
-        String image
+        @Valid
+        List<CustomizationItemImageRequest> images
 ) {
 }

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/CustomizationItemDetailResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/CustomizationItemDetailResponse.java
@@ -11,9 +11,10 @@ public record CustomizationItemDetailResponse(
         String description,
         CustomizationUnlockConditionType unlockConditionType,
         Integer unlockConditionCount,
-        String image
+        String image,
+        String imageWithoutBackground
 ) {
-    public static CustomizationItemDetailResponse from(CustomizationItem model) {
+    public static CustomizationItemDetailResponse from(CustomizationItem model, String image, String imageWithoutBackground) {
         return new CustomizationItemDetailResponse(
                 model.id(),
                 model.name(),
@@ -21,7 +22,8 @@ public record CustomizationItemDetailResponse(
                 model.description(),
                 model.unlockConditionType(),
                 model.unlockConditionCount(),
-                model.image()
+                image,
+                imageWithoutBackground
         );
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/CustomizationItemResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/CustomizationItemResponse.java
@@ -8,9 +8,13 @@ public record CustomizationItemResponse(
         String name,
         CustomizationItemType type,
         boolean isUnlocked,
-        boolean isEquipped
+        boolean isEquipped,
+        String image,
+        String imageWithoutBackground
 ) {
-    public static CustomizationItemResponse from(CustomizationItem model, boolean isUnlocked, boolean isEquipped) {
-        return new CustomizationItemResponse(model.id(), model.name(), model.type(), isUnlocked, isEquipped);
+    public static CustomizationItemResponse from(
+            CustomizationItem model, boolean isUnlocked, boolean isEquipped, String image, String imageWithoutBackground) {
+        return new CustomizationItemResponse(
+                model.id(), model.name(), model.type(), isUnlocked, isEquipped, image, imageWithoutBackground);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/EquippedCustomizationResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/EquippedCustomizationResponse.java
@@ -7,9 +7,10 @@ public record EquippedCustomizationResponse(
         Long id,
         String name,
         CustomizationItemType type,
-        String image
+        String image,
+        String imageWithoutBackground
 ) {
-    public static EquippedCustomizationResponse from(CustomizationItem model) {
-        return new EquippedCustomizationResponse(model.id(), model.name(), model.type(), model.image());
+    public static EquippedCustomizationResponse from(CustomizationItem model, String image, String imageWithoutBackground) {
+        return new EquippedCustomizationResponse(model.id(), model.name(), model.type(), image, imageWithoutBackground);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/UnlockedCustomizationItemResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/UnlockedCustomizationItemResponse.java
@@ -11,9 +11,10 @@ public record UnlockedCustomizationItemResponse(
         String description,
         CustomizationUnlockConditionType unlockConditionType,
         Integer unlockConditionCount,
-        String image
+        String image,
+        String imageWithoutBackground
 ) {
-    public static UnlockedCustomizationItemResponse from(CustomizationItem model) {
+    public static UnlockedCustomizationItemResponse from(CustomizationItem model, String image, String imageWithoutBackground) {
         return new UnlockedCustomizationItemResponse(
                 model.id(),
                 model.name(),
@@ -21,7 +22,8 @@ public record UnlockedCustomizationItemResponse(
                 model.description(),
                 model.unlockConditionType(),
                 model.unlockConditionCount(),
-                model.image()
+                image,
+                imageWithoutBackground
         );
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/test/application/service/TimePerspectiveCategoryService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/application/service/TimePerspectiveCategoryService.java
@@ -42,7 +42,7 @@ public class TimePerspectiveCategoryService {
 
     public void update(@Positive Long categoryId, @Valid TimePerspectiveCategoryUpdateRequest request) {
         TimePerspectiveCategoryEntity timePerspectiveCategoryEntity = getTimePerspectiveCategoryEntity(categoryId);
-        timePerspectiveCategoryEntity.update(request.name(), request.englishName(), request.characterName(), request.personality(), request.description(), request.idealValue());
+        timePerspectiveCategoryEntity.update(request.name(), request.englishName(), request.characterName(), request.personality(), request.description(), request.idealValue(), request.image());
     }
 
     public void delete(@Positive Long categoryId) {

--- a/src/main/java/com/dnd5/timoapi/domain/test/domain/entity/TimePerspectiveCategoryEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/domain/entity/TimePerspectiveCategoryEntity.java
@@ -35,21 +35,25 @@ public class TimePerspectiveCategoryEntity extends BaseEntity {
     @Column(name = "ideal_value", nullable = false)
     private Double idealValue;
 
+    @Column(columnDefinition = "TEXT")
+    private String image;
+
     public static TimePerspectiveCategoryEntity from(TimePerspectiveCategory model) {
-        return new TimePerspectiveCategoryEntity(model.name(), model.englishName(), model.characterName(), model.personality(), model.description(), model.idealValue());
+        return new TimePerspectiveCategoryEntity(model.name(), model.englishName(), model.characterName(), model.personality(), model.description(), model.idealValue(), model.image());
     }
 
     public TimePerspectiveCategory toModel() {
-        return new TimePerspectiveCategory(getId(), getName(), getEnglishName(), getCharacterName(), getPersonality(), getDescription(), getIdealValue(), getCreatedAt(), getUpdatedAt());
+        return new TimePerspectiveCategory(getId(), getName(), getEnglishName(), getCharacterName(), getPersonality(), getDescription(), getIdealValue(), getImage(), getCreatedAt(), getUpdatedAt());
     }
 
-    public void update(String name, String englishName, String characterName, String personality, String description, Double idealValue) {
+    public void update(String name, String englishName, String characterName, String personality, String description, Double idealValue, String image) {
         if (name != null) this.name = name;
         if (englishName != null) this.englishName = englishName;
         if (characterName != null) this.characterName = characterName;
         if (personality != null) this.personality = personality;
         if (description != null) this.description = description;
         if (idealValue != null) this.idealValue = idealValue;
+        if (image != null) this.image = image;
     }
 
 }

--- a/src/main/java/com/dnd5/timoapi/domain/test/domain/model/TimePerspectiveCategory.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/domain/model/TimePerspectiveCategory.java
@@ -10,10 +10,11 @@ public record TimePerspectiveCategory(
         String personality,
         String description,
         Double idealValue,
+        String image,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
-    public static TimePerspectiveCategory create(String name, String englishName, String characterName, String personality, String description, Double idealValue) {
-        return new TimePerspectiveCategory(null, name, englishName, characterName, personality, description, idealValue, null, null);
+    public static TimePerspectiveCategory create(String name, String englishName, String characterName, String personality, String description, Double idealValue, String image) {
+        return new TimePerspectiveCategory(null, name, englishName, characterName, personality, description, idealValue, image, null, null);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/test/domain/repository/TimePerspectiveCategoryRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/domain/repository/TimePerspectiveCategoryRepository.java
@@ -3,5 +3,9 @@ package com.dnd5.timoapi.domain.test.domain.repository;
 import com.dnd5.timoapi.domain.test.domain.entity.TimePerspectiveCategoryEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TimePerspectiveCategoryRepository extends JpaRepository<TimePerspectiveCategoryEntity, Long> {
+
+    List<TimePerspectiveCategoryEntity> findAllByEnglishNameAndDeletedAtIsNull(String englishName);
 }

--- a/src/main/java/com/dnd5/timoapi/domain/test/presentation/request/TimePerspectiveCategoryCreateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/presentation/request/TimePerspectiveCategoryCreateRequest.java
@@ -11,9 +11,10 @@ public record TimePerspectiveCategoryCreateRequest(
         String personality,
         @NotBlank
         String description,
-        Double idealValue
+        Double idealValue,
+        String image
 ) {
     public TimePerspectiveCategory toModel() {
-        return TimePerspectiveCategory.create(name, englishName, characterName, personality, description, idealValue);
+        return TimePerspectiveCategory.create(name, englishName, characterName, personality, description, idealValue, image);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/test/presentation/request/TimePerspectiveCategoryUpdateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/presentation/request/TimePerspectiveCategoryUpdateRequest.java
@@ -10,6 +10,7 @@ public record TimePerspectiveCategoryUpdateRequest(
         String personality,
         @NotBlank
         String description,
-        Double idealValue
+        Double idealValue,
+        String image
 ) {
 }

--- a/src/main/java/com/dnd5/timoapi/domain/test/presentation/response/TimePerspectiveCategoryDetailResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/presentation/response/TimePerspectiveCategoryDetailResponse.java
@@ -11,6 +11,7 @@ public record TimePerspectiveCategoryDetailResponse(
         String personality,
         String description,
         Double idealValue,
+        String image,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -23,6 +24,7 @@ public record TimePerspectiveCategoryDetailResponse(
                 model.personality(),
                 model.description(),
                 model.idealValue(),
+                model.image(),
                 model.createdAt(),
                 model.updatedAt()
         );

--- a/src/main/java/com/dnd5/timoapi/domain/test/presentation/response/TimePerspectiveCategoryResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/test/presentation/response/TimePerspectiveCategoryResponse.java
@@ -11,6 +11,7 @@ public record TimePerspectiveCategoryResponse(
         String personality,
         String description,
         Double idealValue,
+        String image,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -23,6 +24,7 @@ public record TimePerspectiveCategoryResponse(
                 model.personality(),
                 model.description(),
                 model.idealValue(),
+                model.image(),
                 model.createdAt(),
                 model.updatedAt()
         );


### PR DESCRIPTION
## What is this PR? :mag:
커스터마이징 아이템 캐릭터별 이미지 구조 개편

## Changes :memo:
1. 커스터마이징 아이템 캐릭터별 이미지 구조 변경
- customization_items.image 단일 컬럼 → customization_item_images 테이블로 분리 (아이템 × 캐릭터 5종 조합별 이미지)
- 배경 있는 버전(image) / 없는 버전(imageWithoutBackground) 두 URL 저장 가능하도록 개편
- 어드민 API가 images 배열로 캐릭터 5개 이미지 한 번에 등록
- 관련 응답 5곳(목록/단건/장착/해금/최근해금) 전부 로그인 유저 category 기준으로 이미지 반환

2. 시간관 캐릭터 이미지 컬럼 추가
- time_perspective_categories에 image 컬럼 추가, 관련 API 반영

3. 펫이 유저 캐릭터 이미지를 재사용
- 아이템 이름이 "나의 캐릭터 펫"이면 업로드된 이미지 대신 유저의 category로 time_perspective_categories.image를 그대로 가져다 쓰도록 설계

---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customization items now support category-specific images, including versions with and without backgrounds.
  * Item creation and updates can include multiple validated images.
  * Image details are now shown for item listings, equipped items, item details, and newly unlocked items.
  * Time perspective categories now support image uploads, updates, and display.

* **Improvements**
  * Item details now tailor image selection to the current user’s context.
  * Image inputs are validated for required categories and non-empty values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->