### PR TITLE
fix/customization-pet-item-image

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
@@ -142,7 +142,8 @@ public class CustomizationItemService {
                 request.type(),
                 request.description(),
                 request.unlockConditionType(),
-                request.unlockConditionCount()
+                request.unlockConditionCount(),
+                request.usesCharacterImage()
         );
 
         if (request.images() != null) {
@@ -314,17 +315,11 @@ public class CustomizationItemService {
         };
     }
 
-    private static final String CHARACTER_PET_ITEM_NAME = "나의 캐릭터 펫";
-
-    private boolean usesCharacterImage(CustomizationItemEntity item) {
-        return CHARACTER_PET_ITEM_NAME.equals(item.getName());
-    }
-
     private CustomizationItemImage resolveImage(CustomizationItemEntity item, ZtpiCategory category) {
         if (category == null) {
             return null;
         }
-        if (usesCharacterImage(item)) {
+        if (item.isUsesCharacterImage()) {
             return resolveCharacterImage(item.getId(), category);
         }
         return customizationItemImageRepository
@@ -341,7 +336,7 @@ public class CustomizationItemService {
         Map<Long, CustomizationItemImage> result = new HashMap<>();
 
         List<Long> uploadedImageItemIds = items.stream()
-                .filter(item -> !usesCharacterImage(item))
+                .filter(item -> !item.isUsesCharacterImage())
                 .map(CustomizationItemEntity::getId)
                 .toList();
         if (!uploadedImageItemIds.isEmpty()) {
@@ -351,7 +346,7 @@ public class CustomizationItemService {
         }
 
         List<CustomizationItemEntity> characterImageItems = items.stream()
-                .filter(this::usesCharacterImage)
+                .filter(CustomizationItemEntity::isUsesCharacterImage)
                 .toList();
         if (!characterImageItems.isEmpty()) {
             CustomizationItemImage characterImage = resolveCharacterImage(null, category);

--- a/src/main/java/com/dnd5/timoapi/domain/customization/domain/entity/CustomizationItemEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/domain/entity/CustomizationItemEntity.java
@@ -38,13 +38,17 @@ public class CustomizationItemEntity extends BaseEntity {
     @Column(nullable = false)
     private Integer unlockConditionCount;
 
+    @Column(nullable = false)
+    private boolean usesCharacterImage;
+
     public static CustomizationItemEntity from(CustomizationItem model) {
         return new CustomizationItemEntity(
                 model.name(),
                 model.type(),
                 model.description(),
                 model.unlockConditionType(),
-                model.unlockConditionCount()
+                model.unlockConditionCount(),
+                model.usesCharacterImage()
         );
     }
 
@@ -56,6 +60,7 @@ public class CustomizationItemEntity extends BaseEntity {
                 getDescription(),
                 getUnlockConditionType(),
                 getUnlockConditionCount(),
+                isUsesCharacterImage(),
                 getCreatedAt(),
                 getUpdatedAt(),
                 getDeletedAt()
@@ -67,12 +72,14 @@ public class CustomizationItemEntity extends BaseEntity {
             CustomizationItemType type,
             String description,
             CustomizationUnlockConditionType unlockConditionType,
-            Integer unlockConditionCount
+            Integer unlockConditionCount,
+            Boolean usesCharacterImage
     ) {
         if (name != null) this.name = name;
         if (type != null) this.type = type;
         if (description != null) this.description = description;
         if (unlockConditionType != null) this.unlockConditionType = unlockConditionType;
         if (unlockConditionCount != null) this.unlockConditionCount = unlockConditionCount;
+        if (usesCharacterImage != null) this.usesCharacterImage = usesCharacterImage;
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/customization/domain/model/CustomizationItem.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/domain/model/CustomizationItem.java
@@ -12,6 +12,7 @@ public record CustomizationItem(
         String description,
         CustomizationUnlockConditionType unlockConditionType,
         Integer unlockConditionCount,
+        boolean usesCharacterImage,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         LocalDateTime deletedAt
@@ -21,8 +22,9 @@ public record CustomizationItem(
             CustomizationItemType type,
             String description,
             CustomizationUnlockConditionType unlockConditionType,
-            Integer unlockConditionCount
+            Integer unlockConditionCount,
+            boolean usesCharacterImage
     ) {
-        return new CustomizationItem(null, name, type, description, unlockConditionType, unlockConditionCount, null, null, null);
+        return new CustomizationItem(null, name, type, description, unlockConditionType, unlockConditionCount, usesCharacterImage, null, null, null);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemCreateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemCreateRequest.java
@@ -22,11 +22,13 @@ public record CustomizationItemCreateRequest(
         @NotNull
         @Positive
         Integer unlockConditionCount,
+        @NotNull
+        Boolean usesCharacterImage,
         @NotEmpty
         @Valid
         List<CustomizationItemImageCreateRequest> images
 ) {
     public CustomizationItem toModel() {
-        return CustomizationItem.create(name, type, description, unlockConditionType, unlockConditionCount);
+        return CustomizationItem.create(name, type, description, unlockConditionType, unlockConditionCount, usesCharacterImage);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemUpdateRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/request/CustomizationItemUpdateRequest.java
@@ -14,6 +14,7 @@ public record CustomizationItemUpdateRequest(
         CustomizationUnlockConditionType unlockConditionType,
         @Positive
         Integer unlockConditionCount,
+        Boolean usesCharacterImage,
         @Valid
         List<CustomizationItemImageCreateRequest> images
 ) {


### PR DESCRIPTION
## What is this PR? :mag:
캐릭터 펫 이미지 재사용 조건을 이름 매칭 대신 컬럼으로 관리

## Changes :memo:
- customization_items에 usesCharacterImage 컬럼 추가
- 아이템 이름 문자열 하드코딩("나의 캐릭터 펫") 매칭 방식 제거
- 이름이 바뀌어도 캐릭터 이미지 재사용 기능이 깨지지 않도록 개선
- 생성 API는 필수값, 수정 API는 null-safe partial update로 처리

---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customization items can now be configured to use a character’s image.
  * Added character-image settings when creating or updating customization items.
  * Image selection now automatically distinguishes between character images and uploaded item images.

* **Bug Fixes**
  * Improved image resolution for customization items configured to use character images.
  * Character-image settings are now retained consistently when items are saved and updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->