### PR TITLE
feat/admin-customization

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
@@ -186,6 +186,12 @@ public class CustomizationItemService {
     public void delete(Long customizationItemId) {
         CustomizationItemEntity entity = getCustomizationItemEntity(customizationItemId);
         entity.softDelete();
+
+        customizationUserItemRepository.findAllByCustomizationItemIdAndDeletedAtIsNull(customizationItemId)
+                .forEach(CustomizationUserItemEntity::softDelete);
+
+        customizationItemImageRepository.findAllByCustomizationItemIdAndDeletedAtIsNull(customizationItemId)
+                .forEach(CustomizationItemImageEntity::softDelete);
     }
 
     public void equip(Long userId, Long customizationItemId) {

--- a/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
@@ -15,7 +15,10 @@ import com.dnd5.timoapi.domain.customization.exception.CustomizationItemErrorCod
 import com.dnd5.timoapi.domain.customization.presentation.request.CustomizationItemCreateRequest;
 import com.dnd5.timoapi.domain.customization.presentation.request.CustomizationItemImageCreateRequest;
 import com.dnd5.timoapi.domain.customization.presentation.request.CustomizationItemUpdateRequest;
+import com.dnd5.timoapi.domain.customization.presentation.response.AdminCustomizationItemDetailResponse;
+import com.dnd5.timoapi.domain.customization.presentation.response.AdminCustomizationItemResponse;
 import com.dnd5.timoapi.domain.customization.presentation.response.CustomizationItemDetailResponse;
+import com.dnd5.timoapi.domain.customization.presentation.response.CustomizationItemImageResponse;
 import com.dnd5.timoapi.domain.customization.presentation.response.CustomizationItemResponse;
 import com.dnd5.timoapi.domain.customization.presentation.response.EquippedCustomizationResponse;
 import com.dnd5.timoapi.domain.customization.presentation.response.UnlockedCustomizationItemResponse;
@@ -120,6 +123,23 @@ public class CustomizationItemService {
                 entity.toModel(),
                 image != null ? image.image() : null,
                 image != null ? image.imageWithoutBackground() : null);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdminCustomizationItemResponse> findAllForAdmin() {
+        return customizationItemRepository.findAllByDeletedAtIsNull().stream()
+                .map(item -> AdminCustomizationItemResponse.from(item.toModel()))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public AdminCustomizationItemDetailResponse findByIdForAdmin(Long customizationItemId) {
+        CustomizationItemEntity entity = getCustomizationItemEntity(customizationItemId);
+        List<CustomizationItemImageResponse> images = customizationItemImageRepository
+                .findAllByCustomizationItemIdAndDeletedAtIsNull(customizationItemId).stream()
+                .map(imageEntity -> CustomizationItemImageResponse.from(imageEntity.toModel()))
+                .toList();
+        return AdminCustomizationItemDetailResponse.from(entity.toModel(), images);
     }
 
     public void create(CustomizationItemCreateRequest request) {

--- a/src/main/java/com/dnd5/timoapi/domain/customization/domain/repository/CustomizationUserItemRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/domain/repository/CustomizationUserItemRepository.java
@@ -20,4 +20,6 @@ public interface CustomizationUserItemRepository extends JpaRepository<Customiza
 
     List<CustomizationUserItemEntity> findAllByUserIdInAndCustomizationItemIdInAndIsUnlockedTrueAndDeletedAtIsNull(
             Collection<Long> userIds, Collection<Long> customizationItemIds);
+
+    List<CustomizationUserItemEntity> findAllByCustomizationItemIdAndDeletedAtIsNull(Long customizationItemId);
 }

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/AdminCustomizationController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/AdminCustomizationController.java
@@ -3,13 +3,17 @@ package com.dnd5.timoapi.domain.customization.presentation;
 import com.dnd5.timoapi.domain.customization.application.service.CustomizationItemService;
 import com.dnd5.timoapi.domain.customization.presentation.request.CustomizationItemCreateRequest;
 import com.dnd5.timoapi.domain.customization.presentation.request.CustomizationItemUpdateRequest;
+import com.dnd5.timoapi.domain.customization.presentation.response.AdminCustomizationItemDetailResponse;
+import com.dnd5.timoapi.domain.customization.presentation.response.AdminCustomizationItemResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,6 +29,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminCustomizationController {
 
     private final CustomizationItemService customizationItemService;
+
+    @Operation(summary = "커스터마이징 아이템 목록 조회 (어드민)")
+    @GetMapping
+    public List<AdminCustomizationItemResponse> getCustomizations() {
+        return customizationItemService.findAllForAdmin();
+    }
+
+    @Operation(summary = "커스터마이징 아이템 상세 조회 (어드민)")
+    @GetMapping("/{customizationItemId}")
+    public AdminCustomizationItemDetailResponse getCustomization(@Positive @PathVariable Long customizationItemId) {
+        return customizationItemService.findByIdForAdmin(customizationItemId);
+    }
 
     @Operation(summary = "커스터마이징 아이템 생성 (어드민)")
     @PostMapping

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/AdminCustomizationItemDetailResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/AdminCustomizationItemDetailResponse.java
@@ -1,0 +1,31 @@
+package com.dnd5.timoapi.domain.customization.presentation.response;
+
+import com.dnd5.timoapi.domain.customization.domain.model.CustomizationItem;
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationItemType;
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationUnlockConditionType;
+
+import java.util.List;
+
+public record AdminCustomizationItemDetailResponse(
+        Long id,
+        String name,
+        CustomizationItemType type,
+        String description,
+        CustomizationUnlockConditionType unlockConditionType,
+        Integer unlockConditionCount,
+        boolean usesCharacterImage,
+        List<CustomizationItemImageResponse> images
+) {
+    public static AdminCustomizationItemDetailResponse from(CustomizationItem model, List<CustomizationItemImageResponse> images) {
+        return new AdminCustomizationItemDetailResponse(
+                model.id(),
+                model.name(),
+                model.type(),
+                model.description(),
+                model.unlockConditionType(),
+                model.unlockConditionCount(),
+                model.usesCharacterImage(),
+                images
+        );
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/AdminCustomizationItemResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/AdminCustomizationItemResponse.java
@@ -1,0 +1,27 @@
+package com.dnd5.timoapi.domain.customization.presentation.response;
+
+import com.dnd5.timoapi.domain.customization.domain.model.CustomizationItem;
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationItemType;
+import com.dnd5.timoapi.domain.customization.domain.model.enums.CustomizationUnlockConditionType;
+
+public record AdminCustomizationItemResponse(
+        Long id,
+        String name,
+        CustomizationItemType type,
+        String description,
+        CustomizationUnlockConditionType unlockConditionType,
+        Integer unlockConditionCount,
+        boolean usesCharacterImage
+) {
+    public static AdminCustomizationItemResponse from(CustomizationItem model) {
+        return new AdminCustomizationItemResponse(
+                model.id(),
+                model.name(),
+                model.type(),
+                model.description(),
+                model.unlockConditionType(),
+                model.unlockConditionCount(),
+                model.usesCharacterImage()
+        );
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/CustomizationItemImageResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/presentation/response/CustomizationItemImageResponse.java
@@ -1,0 +1,14 @@
+package com.dnd5.timoapi.domain.customization.presentation.response;
+
+import com.dnd5.timoapi.domain.customization.domain.model.CustomizationItemImage;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+
+public record CustomizationItemImageResponse(
+        ZtpiCategory category,
+        String image,
+        String imageWithoutBackground
+) {
+    public static CustomizationItemImageResponse from(CustomizationItemImage model) {
+        return new CustomizationItemImageResponse(model.category(), model.image(), model.imageWithoutBackground());
+    }
+}


### PR DESCRIPTION
## What is this PR? :mag:
커스터마이징 아이템 어드민 조회 API 및 삭제 정합성 보완

## Changes :memo:
1. 커스터마이징 아이템 어드민 조회 API 추가
- GET /admin/customizations, GET /admin/customizations/{id} 추가
- 기존 GET /customizations: 로그인된 유저의 category/해금/장착 상태를 조회 -> 관리자 계정으로 로그인하는 관리자 페이지에서 활용하기에 부적합 -> 관리자용으로 추가로 만듬
- 어드민 상세 조회 응답은 카테고리 5종 × (배경 있는 이미지 / 배경 없는 이미지) 전체 이미지와 usesCharacterImage 값을 함께 반환

2. 커스터마이징 아이템 삭제 시 연관 데이터 처리
- 아이템을 soft delete해도 유저의 customization_user_items(해금/장착 상태), customization_item_images(카테고리별 이미지)는 그대로 남아있던 문제
- 특히 장착 중이던 아이템을 삭제해도 유저 응답(GET /users/me)에는 계속 노출, 이 상태에서 unequip 호출 시 아이템 자체가 없어 404 오류가 발생하는 문제 개선
- 아이템 삭제 시 연관된 두 데이터도 함께 soft delete 하도록 수정

---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin endpoints to list available customization items.
  * Added an admin detail view showing customization metadata and associated images.
  * Added image information to customization detail responses.

* **Bug Fixes**
  * Deleting a customization item now also removes its associated user assignments and images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->