### PR TITLE
feat/group-member-reflection-calendar

### DIFF
--- a/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/customization/application/service/CustomizationItemService.java
@@ -114,6 +114,21 @@ public class CustomizationItemService {
     }
 
     @Transactional(readOnly = true)
+    public CustomizationItemImage findEquippedThemeImage(Long userId, ZtpiCategory category) {
+        if (category == null) {
+            return null;
+        }
+
+        return customizationUserItemRepository.findAllByUserIdAndIsEquippedTrueAndDeletedAtIsNull(userId).stream()
+                .map(userItem -> customizationItemRepository.findByIdAndDeletedAtIsNull(userItem.getCustomizationItemId()))
+                .flatMap(Optional::stream)
+                .filter(item -> item.getType() == CustomizationItemType.THEME)
+                .findFirst()
+                .map(item -> resolveImage(item, category))
+                .orElse(null);
+    }
+
+    @Transactional(readOnly = true)
     public CustomizationItemDetailResponse findById(Long userId, Long customizationItemId) {
         UserEntity user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupReflectionCommentService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupReflectionCommentService.java
@@ -1,0 +1,123 @@
+package com.dnd5.timoapi.domain.group.application.service;
+
+import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberEntity;
+import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberReflectionCommentEntity;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberReflectionCommentRepository;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberReflectionPrivateRepository;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberRepository;
+import com.dnd5.timoapi.domain.group.exception.GroupErrorCode;
+import com.dnd5.timoapi.domain.group.presentation.request.GroupReflectionCommentRequest;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupReflectionCommentResponse;
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
+import com.dnd5.timoapi.domain.reflection.exception.ReflectionErrorCode;
+import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
+import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
+import com.dnd5.timoapi.global.exception.BusinessException;
+import com.dnd5.timoapi.global.security.context.SecurityUtil;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GroupReflectionCommentService {
+
+    private final GroupMemberRepository groupMemberRepository;
+    private final ReflectionRepository reflectionRepository;
+    private final GroupMemberReflectionPrivateRepository groupMemberReflectionPrivateRepository;
+    private final GroupMemberReflectionCommentRepository groupMemberReflectionCommentRepository;
+    private final UserRepository userRepository;
+
+    public void create(Long groupId, Long reflectionId, GroupReflectionCommentRequest request) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        getAccessibleGroupReflection(groupId, reflectionId, userId);
+
+        groupMemberReflectionCommentRepository.save(
+                new GroupMemberReflectionCommentEntity(groupId, reflectionId, userId, request.content()));
+    }
+
+    @Transactional(readOnly = true)
+    public List<GroupReflectionCommentResponse> findAll(Long groupId, Long reflectionId) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        getAccessibleGroupReflection(groupId, reflectionId, userId);
+
+        List<GroupMemberReflectionCommentEntity> comments = groupMemberReflectionCommentRepository
+                .findAllByGroupIdAndReflectionIdAndDeletedAtIsNullOrderByCreatedAtAsc(groupId, reflectionId);
+
+        if (comments.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> commenterIds = comments.stream()
+                .map(GroupMemberReflectionCommentEntity::getUserId).distinct().toList();
+        Map<Long, UserEntity> userMap = userRepository.findAllById(commenterIds)
+                .stream().collect(Collectors.toMap(UserEntity::getId, u -> u));
+
+        return comments.stream()
+                .map(comment -> {
+                    UserEntity commenter = userMap.get(comment.getUserId());
+                    return new GroupReflectionCommentResponse(
+                            comment.getId(),
+                            comment.getUserId(),
+                            commenter != null ? commenter.getNickname() : null,
+                            comment.getContent(),
+                            comment.getCreatedAt()
+                    );
+                })
+                .toList();
+    }
+
+    public void update(Long groupId, Long reflectionId, Long commentId, GroupReflectionCommentRequest request) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        GroupMemberReflectionCommentEntity comment = getOwnedComment(groupId, reflectionId, commentId, userId);
+        comment.update(request.content());
+    }
+
+    public void delete(Long groupId, Long reflectionId, Long commentId) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        GroupMemberReflectionCommentEntity comment = getOwnedComment(groupId, reflectionId, commentId, userId);
+        comment.softDelete();
+    }
+
+    private GroupMemberReflectionCommentEntity getOwnedComment(
+            Long groupId, Long reflectionId, Long commentId, Long userId) {
+        GroupMemberReflectionCommentEntity comment = groupMemberReflectionCommentRepository
+                .findByIdAndGroupIdAndReflectionIdAndDeletedAtIsNull(commentId, groupId, reflectionId)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.GROUP_REFLECTION_COMMENT_NOT_FOUND));
+
+        if (!comment.getUserId().equals(userId)) {
+            throw new BusinessException(
+                    GroupErrorCode.GROUP_REFLECTION_COMMENT_NOT_OWNER, commentId, comment.getUserId(), userId);
+        }
+        return comment;
+    }
+
+    private ReflectionEntity getAccessibleGroupReflection(Long groupId, Long reflectionId, Long viewerId) {
+        if (!groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)) {
+            throw new BusinessException(GroupErrorCode.GROUP_ACCESS_DENIED);
+        }
+
+        ReflectionEntity reflectionEntity = reflectionRepository.findById(reflectionId)
+                .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_NOT_FOUND));
+
+        GroupMemberEntity authorMember = groupMemberRepository
+                .findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, reflectionEntity.getUserId())
+                .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_NOT_FOUND));
+
+        if (reflectionEntity.getDate().isBefore(authorMember.getCreatedAt().toLocalDate())) {
+            throw new BusinessException(ReflectionErrorCode.REFLECTION_NOT_FOUND);
+        }
+
+        boolean isPrivate = groupMemberReflectionPrivateRepository.existsByGroupIdAndReflectionId(groupId, reflectionId);
+        if (isPrivate && !reflectionEntity.getUserId().equals(viewerId)) {
+            throw new BusinessException(GroupErrorCode.GROUP_ACCESS_DENIED);
+        }
+
+        return reflectionEntity;
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupReflectionCommentService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupReflectionCommentService.java
@@ -65,6 +65,7 @@ public class GroupReflectionCommentService {
                             comment.getId(),
                             comment.getUserId(),
                             commenter != null ? commenter.getNickname() : null,
+                            commenter != null ? commenter.getCategory() : null,
                             comment.getContent(),
                             comment.getCreatedAt()
                     );

--- a/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupReflectionLikeService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupReflectionLikeService.java
@@ -1,0 +1,76 @@
+package com.dnd5.timoapi.domain.group.application.service;
+
+import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberEntity;
+import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberReflectionLikeEntity;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberReflectionLikeRepository;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberReflectionPrivateRepository;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberRepository;
+import com.dnd5.timoapi.domain.group.exception.GroupErrorCode;
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
+import com.dnd5.timoapi.domain.reflection.exception.ReflectionErrorCode;
+import com.dnd5.timoapi.global.exception.BusinessException;
+import com.dnd5.timoapi.global.security.context.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GroupReflectionLikeService {
+
+    private final GroupMemberRepository groupMemberRepository;
+    private final ReflectionRepository reflectionRepository;
+    private final GroupMemberReflectionPrivateRepository groupMemberReflectionPrivateRepository;
+    private final GroupMemberReflectionLikeRepository groupMemberReflectionLikeRepository;
+
+    public void like(Long groupId, Long reflectionId) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        getAccessibleGroupReflection(groupId, reflectionId, userId);
+
+        if (groupMemberReflectionLikeRepository.existsByGroupIdAndReflectionIdAndUserId(groupId, reflectionId, userId)) {
+            throw new BusinessException(GroupErrorCode.GROUP_REFLECTION_LIKE_ALREADY_EXISTS);
+        }
+
+        groupMemberReflectionLikeRepository.save(
+                new GroupMemberReflectionLikeEntity(groupId, reflectionId, userId));
+    }
+
+    public void unlike(Long groupId, Long reflectionId) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        if (!groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)) {
+            throw new BusinessException(GroupErrorCode.GROUP_ACCESS_DENIED);
+        }
+
+        GroupMemberReflectionLikeEntity like = groupMemberReflectionLikeRepository
+                .findByGroupIdAndReflectionIdAndUserId(groupId, reflectionId, userId)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.GROUP_REFLECTION_LIKE_NOT_FOUND));
+
+        groupMemberReflectionLikeRepository.delete(like);
+    }
+
+    private ReflectionEntity getAccessibleGroupReflection(Long groupId, Long reflectionId, Long viewerId) {
+        if (!groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)) {
+            throw new BusinessException(GroupErrorCode.GROUP_ACCESS_DENIED);
+        }
+
+        ReflectionEntity reflectionEntity = reflectionRepository.findById(reflectionId)
+                .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_NOT_FOUND));
+
+        GroupMemberEntity authorMember = groupMemberRepository
+                .findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, reflectionEntity.getUserId())
+                .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_NOT_FOUND));
+
+        if (reflectionEntity.getDate().isBefore(authorMember.getCreatedAt().toLocalDate())) {
+            throw new BusinessException(ReflectionErrorCode.REFLECTION_NOT_FOUND);
+        }
+
+        boolean isPrivate = groupMemberReflectionPrivateRepository.existsByGroupIdAndReflectionId(groupId, reflectionId);
+        if (isPrivate && !reflectionEntity.getUserId().equals(viewerId)) {
+            throw new BusinessException(GroupErrorCode.GROUP_ACCESS_DENIED);
+        }
+
+        return reflectionEntity;
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/application/service/GroupService.java
@@ -2,11 +2,15 @@ package com.dnd5.timoapi.domain.group.application.service;
 
 import com.dnd5.timoapi.domain.group.domain.entity.GroupEntity;
 import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberEntity;
+import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberReflectionPrivateEntity;
 import com.dnd5.timoapi.domain.group.domain.model.Group;
 import com.dnd5.timoapi.domain.group.domain.model.GroupMember;
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupMemberRole;
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupReflectionSort;
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberReflectionCommentRepository;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberReflectionLikeRepository;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberReflectionPrivateRepository;
 import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberRepository;
 import com.dnd5.timoapi.domain.group.domain.repository.GroupRepository;
 import com.dnd5.timoapi.domain.group.exception.GroupErrorCode;
@@ -14,12 +18,16 @@ import com.dnd5.timoapi.domain.group.presentation.request.GroupCreateRequest;
 import com.dnd5.timoapi.domain.group.presentation.request.GroupUpdateRequest;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupCreateResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupDetailResponse;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupMemberReflectionDetailResponse;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupMemberReflectionResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupTodayReflectionItem;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionQuestionEntity;
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionQuestionRepository;
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
+import com.dnd5.timoapi.domain.reflection.exception.ReflectionErrorCode;
+import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionQuestionResponse;
 import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
 import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
@@ -47,6 +55,9 @@ public class GroupService {
     private final ReflectionRepository reflectionRepository;
     private final ReflectionQuestionRepository reflectionQuestionRepository;
     private final UserRepository userRepository;
+    private final GroupMemberReflectionPrivateRepository groupMemberReflectionPrivateRepository;
+    private final GroupMemberReflectionLikeRepository groupMemberReflectionLikeRepository;
+    private final GroupMemberReflectionCommentRepository groupMemberReflectionCommentRepository;
 
     public GroupCreateResponse createGroup(GroupCreateRequest request) {
         if (request.type() == GroupType.CHARACTER) {
@@ -216,13 +227,100 @@ public class GroupService {
         LocalDate today = LocalDate.now();
 
         if (groupEntity.getType() == GroupType.CHARACTER) {
-            return getTodayReflectionsForCharacterGroup(groupEntity, today, sort);
+            return getTodayReflectionsForCharacterGroup(groupEntity, userId, today, sort);
         }
         return getTodayReflectionsForFriendGroup(groupId, userId, today, sort);
     }
 
+    @Transactional(readOnly = true)
+    public GroupMemberReflectionDetailResponse getMemberReflection(Long groupId, Long reflectionId) {
+        Long viewerId = SecurityUtil.getCurrentUserId();
+        if (!groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)) {
+            throw new BusinessException(GroupErrorCode.GROUP_ACCESS_DENIED);
+        }
+
+        ReflectionEntity reflectionEntity = reflectionRepository.findById(reflectionId)
+                .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_NOT_FOUND));
+
+        GroupMemberEntity authorMember = groupMemberRepository
+                .findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, reflectionEntity.getUserId())
+                .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_NOT_FOUND));
+
+        if (reflectionEntity.getDate().isBefore(authorMember.getCreatedAt().toLocalDate())) {
+            throw new BusinessException(ReflectionErrorCode.REFLECTION_NOT_FOUND);
+        }
+
+        ReflectionQuestionEntity questionEntity = reflectionQuestionRepository.findById(reflectionEntity.getQuestionId())
+                .orElseThrow(() -> new BusinessException(ReflectionErrorCode.REFLECTION_QUESTION_NOT_FOUND));
+
+        boolean isPrivate = groupMemberReflectionPrivateRepository
+                .existsByGroupIdAndReflectionId(groupId, reflectionId);
+        boolean isOwner = reflectionEntity.getUserId().equals(viewerId);
+        String content = (isPrivate && !isOwner) ? null : reflectionEntity.getAnswerText();
+
+        long likeCount = groupMemberReflectionLikeRepository.countByGroupIdAndReflectionId(groupId, reflectionId);
+        long commentCount = groupMemberReflectionCommentRepository
+                .countByGroupIdAndReflectionIdAndDeletedAtIsNull(groupId, reflectionId);
+
+        return new GroupMemberReflectionDetailResponse(
+                reflectionEntity.getId(),
+                ReflectionQuestionResponse.from(questionEntity.toModel()),
+                content,
+                reflectionEntity.getDate(),
+                likeCount,
+                commentCount
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<GroupMemberReflectionResponse> getMemberCalendar(Long groupId, Long userId) {
+        Long viewerId = SecurityUtil.getCurrentUserId();
+        if (!groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)) {
+            throw new BusinessException(GroupErrorCode.GROUP_ACCESS_DENIED);
+        }
+
+        GroupMemberEntity targetMember = groupMemberRepository
+                .findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.GROUP_MEMBER_NOT_FOUND));
+
+        LocalDate joinedDate = targetMember.getCreatedAt().toLocalDate();
+        List<ReflectionEntity> reflections = reflectionRepository
+                .findAllByUserIdAndDateBetween(userId, joinedDate, LocalDate.now());
+
+        if (reflections.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> questionIds = reflections.stream().map(ReflectionEntity::getQuestionId).distinct().toList();
+        Map<Long, ReflectionQuestionEntity> questionMap = reflectionQuestionRepository.findAllById(questionIds)
+                .stream().collect(Collectors.toMap(ReflectionQuestionEntity::getId, q -> q));
+
+        List<Long> reflectionIds = reflections.stream().map(ReflectionEntity::getId).toList();
+        Set<Long> privateReflectionIds = groupMemberReflectionPrivateRepository
+                .findAllByGroupIdAndReflectionIdIn(groupId, reflectionIds)
+                .stream().map(GroupMemberReflectionPrivateEntity::getReflectionId).collect(Collectors.toSet());
+
+        boolean isOwner = userId.equals(viewerId);
+
+        return reflections.stream()
+                .sorted(Comparator.comparing(ReflectionEntity::getDate))
+                .map(reflection -> {
+                    boolean isPrivate = privateReflectionIds.contains(reflection.getId());
+                    ReflectionQuestionEntity question = questionMap.get(reflection.getQuestionId());
+                    String content = (isPrivate && !isOwner) ? null : reflection.getAnswerText();
+                    return new GroupMemberReflectionResponse(
+                            reflection.getId(),
+                            question != null ? ReflectionQuestionResponse.from(question.toModel()) : null,
+                            content,
+                            !isPrivate,
+                            reflection.getDate()
+                    );
+                })
+                .toList();
+    }
+
     private List<GroupTodayReflectionItem> getTodayReflectionsForCharacterGroup(
-            GroupEntity groupEntity, LocalDate today, GroupReflectionSort sort) {
+            GroupEntity groupEntity, Long viewerId, LocalDate today, GroupReflectionSort sort) {
         List<Long> memberUserIds = groupMemberRepository.findAllByGroupIdAndDeletedAtIsNull(groupEntity.getId())
                 .stream().map(GroupMemberEntity::getUserId).toList();
 
@@ -242,6 +340,8 @@ public class GroupService {
         Map<Long, ReflectionQuestionEntity> questionMap = questionIds.isEmpty() ? Map.of() :
                 reflectionQuestionRepository.findAllById(questionIds)
                         .stream().collect(Collectors.toMap(ReflectionQuestionEntity::getId, q -> q));
+
+        Set<Long> privateReflectionIds = getPrivateReflectionIds(groupEntity.getId(), reflectionByUserId);
 
         Comparator<Long> comparator = switch (sort) {
             case STREAK -> Comparator.comparingInt((Long uid) -> {
@@ -268,13 +368,17 @@ public class GroupService {
                     UserEntity user = userMap.get(uid);
                     ReflectionEntity reflection = reflectionByUserId.get(uid);
                     ReflectionQuestionEntity question = reflection != null ? questionMap.get(reflection.getQuestionId()) : null;
+                    boolean isPrivate = reflection != null && privateReflectionIds.contains(reflection.getId());
+                    boolean isOwner = uid.equals(viewerId);
                     return new GroupTodayReflectionItem(
                             uid,
+                            reflection != null ? reflection.getId() : null,
                             user != null ? user.getNickname() : null,
                             user != null ? user.getCategory() : null,
                             question != null ? question.getContent() : null,
                             question != null ? question.getCategory() : null,
-                            reflection != null ? reflection.getAnswerText() : null,
+                            reflection != null && !(isPrivate && !isOwner) ? reflection.getAnswerText() : null,
+                            !isPrivate,
                             user != null ? user.getStreakDays() : 0,
                             user != null ? user.getTotalDays() : 0
                     );
@@ -309,6 +413,8 @@ public class GroupService {
                 reflectionQuestionRepository.findAllById(questionIds)
                         .stream().collect(Collectors.toMap(ReflectionQuestionEntity::getId, q -> q));
 
+        Set<Long> privateReflectionIds = getPrivateReflectionIds(groupId, reflectionByUserId);
+
         Comparator<Long> comparator = switch (sort) {
             case STREAK -> Comparator.comparingInt((Long uid) -> {
                 UserEntity u = userMap.get(uid);
@@ -334,18 +440,31 @@ public class GroupService {
                     UserEntity user = userMap.get(uid);
                     ReflectionEntity reflection = reflectionByUserId.get(uid);
                     ReflectionQuestionEntity question = reflection != null ? questionMap.get(reflection.getQuestionId()) : null;
+                    boolean isPrivate = reflection != null && privateReflectionIds.contains(reflection.getId());
+                    boolean isOwner = uid.equals(userId);
                     return new GroupTodayReflectionItem(
                             uid,
+                            reflection != null ? reflection.getId() : null,
                             user != null ? user.getNickname() : null,
                             user != null ? user.getCategory() : null,
                             question != null ? question.getContent() : null,
                             question != null ? question.getCategory() : null,
-                            reflection != null ? reflection.getAnswerText() : null,
+                            reflection != null && !(isPrivate && !isOwner) ? reflection.getAnswerText() : null,
+                            !isPrivate,
                             user != null ? user.getStreakDays() : 0,
                             user != null ? user.getTotalDays() : 0
                     );
                 })
                 .toList();
+    }
+
+    private Set<Long> getPrivateReflectionIds(Long groupId, Map<Long, ReflectionEntity> reflectionByUserId) {
+        List<Long> reflectionIds = reflectionByUserId.values().stream().map(ReflectionEntity::getId).toList();
+        if (reflectionIds.isEmpty()) {
+            return Set.of();
+        }
+        return groupMemberReflectionPrivateRepository.findAllByGroupIdAndReflectionIdIn(groupId, reflectionIds)
+                .stream().map(GroupMemberReflectionPrivateEntity::getReflectionId).collect(Collectors.toSet());
     }
 
     private void handleOwnerLeave(Long groupId, GroupMemberEntity ownerMember) {

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/entity/GroupMemberReflectionCommentEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/entity/GroupMemberReflectionCommentEntity.java
@@ -27,4 +27,8 @@ public class GroupMemberReflectionCommentEntity extends BaseEntity {
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
+
+    public void update(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/entity/GroupMemberReflectionCommentEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/entity/GroupMemberReflectionCommentEntity.java
@@ -1,0 +1,30 @@
+package com.dnd5.timoapi.domain.group.domain.entity;
+
+import com.dnd5.timoapi.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(name = "user_group_member_reflection_comments")
+public class GroupMemberReflectionCommentEntity extends BaseEntity {
+
+    @Column(name = "group_id", nullable = false)
+    private Long groupId;
+
+    @Column(name = "reflection_id", nullable = false)
+    private Long reflectionId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/entity/GroupMemberReflectionLikeEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/entity/GroupMemberReflectionLikeEntity.java
@@ -1,0 +1,31 @@
+package com.dnd5.timoapi.domain.group.domain.entity;
+
+import com.dnd5.timoapi.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(
+        name = "user_group_member_reflection_likes",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"group_id", "reflection_id", "user_id"})
+)
+public class GroupMemberReflectionLikeEntity extends BaseEntity {
+
+    @Column(name = "group_id", nullable = false)
+    private Long groupId;
+
+    @Column(name = "reflection_id", nullable = false)
+    private Long reflectionId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/entity/GroupMemberReflectionPrivateEntity.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/entity/GroupMemberReflectionPrivateEntity.java
@@ -1,0 +1,28 @@
+package com.dnd5.timoapi.domain.group.domain.entity;
+
+import com.dnd5.timoapi.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(
+        name = "user_group_member_reflection_privates",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"group_id", "reflection_id"})
+)
+public class GroupMemberReflectionPrivateEntity extends BaseEntity {
+
+    @Column(name = "group_id", nullable = false)
+    private Long groupId;
+
+    @Column(name = "reflection_id", nullable = false)
+    private Long reflectionId;
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupMemberReflectionCommentRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupMemberReflectionCommentRepository.java
@@ -1,9 +1,17 @@
 package com.dnd5.timoapi.domain.group.domain.repository;
 
 import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberReflectionCommentEntity;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupMemberReflectionCommentRepository extends JpaRepository<GroupMemberReflectionCommentEntity, Long> {
 
     long countByGroupIdAndReflectionIdAndDeletedAtIsNull(Long groupId, Long reflectionId);
+
+    List<GroupMemberReflectionCommentEntity> findAllByGroupIdAndReflectionIdAndDeletedAtIsNullOrderByCreatedAtAsc(
+            Long groupId, Long reflectionId);
+
+    Optional<GroupMemberReflectionCommentEntity> findByIdAndGroupIdAndReflectionIdAndDeletedAtIsNull(
+            Long id, Long groupId, Long reflectionId);
 }

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupMemberReflectionCommentRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupMemberReflectionCommentRepository.java
@@ -1,0 +1,9 @@
+package com.dnd5.timoapi.domain.group.domain.repository;
+
+import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberReflectionCommentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupMemberReflectionCommentRepository extends JpaRepository<GroupMemberReflectionCommentEntity, Long> {
+
+    long countByGroupIdAndReflectionIdAndDeletedAtIsNull(Long groupId, Long reflectionId);
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupMemberReflectionLikeRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupMemberReflectionLikeRepository.java
@@ -1,0 +1,9 @@
+package com.dnd5.timoapi.domain.group.domain.repository;
+
+import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberReflectionLikeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupMemberReflectionLikeRepository extends JpaRepository<GroupMemberReflectionLikeEntity, Long> {
+
+    long countByGroupIdAndReflectionId(Long groupId, Long reflectionId);
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupMemberReflectionLikeRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupMemberReflectionLikeRepository.java
@@ -1,9 +1,14 @@
 package com.dnd5.timoapi.domain.group.domain.repository;
 
 import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberReflectionLikeEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupMemberReflectionLikeRepository extends JpaRepository<GroupMemberReflectionLikeEntity, Long> {
 
     long countByGroupIdAndReflectionId(Long groupId, Long reflectionId);
+
+    boolean existsByGroupIdAndReflectionIdAndUserId(Long groupId, Long reflectionId, Long userId);
+
+    Optional<GroupMemberReflectionLikeEntity> findByGroupIdAndReflectionIdAndUserId(Long groupId, Long reflectionId, Long userId);
 }

--- a/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupMemberReflectionPrivateRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/domain/repository/GroupMemberReflectionPrivateRepository.java
@@ -1,0 +1,12 @@
+package com.dnd5.timoapi.domain.group.domain.repository;
+
+import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberReflectionPrivateEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupMemberReflectionPrivateRepository extends JpaRepository<GroupMemberReflectionPrivateEntity, Long> {
+
+    boolean existsByGroupIdAndReflectionId(Long groupId, Long reflectionId);
+
+    List<GroupMemberReflectionPrivateEntity> findAllByGroupIdAndReflectionIdIn(Long groupId, List<Long> reflectionIds);
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/exception/GroupErrorCode.java
@@ -18,6 +18,10 @@ public enum GroupErrorCode implements ErrorCode {
     GROUP_CATEGORY_NOT_SET(HttpStatus.BAD_REQUEST, "캐릭터 유형이 설정되지 않았습니다."),
     GROUP_TYPE_REQUIRED(HttpStatus.BAD_REQUEST, "그룹 타입을 지정해야 합니다."),
     GROUP_CHARACTER_IMMUTABLE(HttpStatus.FORBIDDEN, "캐릭터 그룹은 수정하거나 삭제할 수 없습니다."),
+    GROUP_REFLECTION_LIKE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 좋아요를 누른 회고입니다."),
+    GROUP_REFLECTION_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요를 찾을 수 없습니다."),
+    GROUP_REFLECTION_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+    GROUP_REFLECTION_COMMENT_NOT_OWNER(HttpStatus.FORBIDDEN, "댓글 작성자만 수정하거나 삭제할 수 있습니다. (commentId: %s, commentUserId: %s, currentUserId: %s)"),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/GroupController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/GroupController.java
@@ -6,6 +6,8 @@ import com.dnd5.timoapi.domain.group.presentation.request.GroupUpdateRequest;
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupCreateResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupDetailResponse;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupMemberReflectionDetailResponse;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupMemberReflectionResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupResponse;
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupReflectionSort;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupTodayReflectionItem;
@@ -97,5 +99,21 @@ public class GroupController {
             @Positive @PathVariable Long groupId,
             @RequestParam(defaultValue = "LATEST") GroupReflectionSort sort) {
         return groupService.getTodayReflections(groupId, sort);
+    }
+
+    @Operation(summary = "그룹 멤버 회고 상세 조회")
+    @GetMapping("/{groupId}/reflections/{reflectionId}")
+    public GroupMemberReflectionDetailResponse getMemberReflection(
+            @Positive @PathVariable Long groupId,
+            @Positive @PathVariable Long reflectionId) {
+        return groupService.getMemberReflection(groupId, reflectionId);
+    }
+
+    @Operation(summary = "그룹 멤버 캘린더 조회")
+    @GetMapping("/{groupId}/members/{userId}/calendar")
+    public List<GroupMemberReflectionResponse> getMemberCalendar(
+            @Positive @PathVariable Long groupId,
+            @Positive @PathVariable Long userId) {
+        return groupService.getMemberCalendar(groupId, userId);
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/GroupReflectionCommentController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/GroupReflectionCommentController.java
@@ -1,0 +1,69 @@
+package com.dnd5.timoapi.domain.group.presentation;
+
+import com.dnd5.timoapi.domain.group.application.service.GroupReflectionCommentService;
+import com.dnd5.timoapi.domain.group.presentation.request.GroupReflectionCommentRequest;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupReflectionCommentResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/groups/{groupId}/reflections/{reflectionId}/comments")
+@RequiredArgsConstructor
+@Validated
+public class GroupReflectionCommentController {
+
+    private final GroupReflectionCommentService groupReflectionCommentService;
+
+    @Operation(summary = "그룹 멤버 회고 댓글 등록")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public void create(
+            @Positive @PathVariable Long groupId,
+            @Positive @PathVariable Long reflectionId,
+            @Valid @RequestBody GroupReflectionCommentRequest request) {
+        groupReflectionCommentService.create(groupId, reflectionId, request);
+    }
+
+    @Operation(summary = "그룹 멤버 회고 댓글 조회")
+    @GetMapping
+    public List<GroupReflectionCommentResponse> findAll(
+            @Positive @PathVariable Long groupId,
+            @Positive @PathVariable Long reflectionId) {
+        return groupReflectionCommentService.findAll(groupId, reflectionId);
+    }
+
+    @Operation(summary = "그룹 멤버 회고 댓글 수정")
+    @PutMapping("/{commentId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void update(
+            @Positive @PathVariable Long groupId,
+            @Positive @PathVariable Long reflectionId,
+            @Positive @PathVariable Long commentId,
+            @Valid @RequestBody GroupReflectionCommentRequest request) {
+        groupReflectionCommentService.update(groupId, reflectionId, commentId, request);
+    }
+
+    @Operation(summary = "그룹 멤버 회고 댓글 삭제")
+    @DeleteMapping("/{commentId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(
+            @Positive @PathVariable Long groupId,
+            @Positive @PathVariable Long reflectionId,
+            @Positive @PathVariable Long commentId) {
+        groupReflectionCommentService.delete(groupId, reflectionId, commentId);
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/GroupReflectionLikeController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/GroupReflectionLikeController.java
@@ -1,0 +1,37 @@
+package com.dnd5.timoapi.domain.group.presentation;
+
+import com.dnd5.timoapi.domain.group.application.service.GroupReflectionLikeService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/groups/{groupId}/reflections/{reflectionId}/like")
+@RequiredArgsConstructor
+@Validated
+public class GroupReflectionLikeController {
+
+    private final GroupReflectionLikeService groupReflectionLikeService;
+
+    @Operation(summary = "그룹 멤버 회고 좋아요 등록")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public void like(@Positive @PathVariable Long groupId, @Positive @PathVariable Long reflectionId) {
+        groupReflectionLikeService.like(groupId, reflectionId);
+    }
+
+    @Operation(summary = "그룹 멤버 회고 좋아요 삭제")
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void unlike(@Positive @PathVariable Long groupId, @Positive @PathVariable Long reflectionId) {
+        groupReflectionLikeService.unlike(groupId, reflectionId);
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/request/GroupReflectionCommentRequest.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/request/GroupReflectionCommentRequest.java
@@ -1,0 +1,11 @@
+package com.dnd5.timoapi.domain.group.presentation.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record GroupReflectionCommentRequest(
+        @NotBlank(message = "댓글 내용은 필수입니다.")
+        @Size(max = 1000, message = "댓글 내용은 1000자 이하여야 합니다.")
+        String content
+) {
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupMemberReflectionDetailResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupMemberReflectionDetailResponse.java
@@ -1,0 +1,14 @@
+package com.dnd5.timoapi.domain.group.presentation.response;
+
+import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionQuestionResponse;
+import java.time.LocalDate;
+
+public record GroupMemberReflectionDetailResponse(
+        Long id,
+        ReflectionQuestionResponse question,
+        String content,
+        LocalDate reflectedAt,
+        long likes,
+        long comments
+) {
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupMemberReflectionResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupMemberReflectionResponse.java
@@ -1,0 +1,13 @@
+package com.dnd5.timoapi.domain.group.presentation.response;
+
+import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionQuestionResponse;
+import java.time.LocalDate;
+
+public record GroupMemberReflectionResponse(
+        Long id,
+        ReflectionQuestionResponse question,
+        String content,
+        boolean isPublic,
+        LocalDate reflectedAt
+) {
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupReflectionCommentResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupReflectionCommentResponse.java
@@ -1,0 +1,12 @@
+package com.dnd5.timoapi.domain.group.presentation.response;
+
+import java.time.LocalDateTime;
+
+public record GroupReflectionCommentResponse(
+        Long id,
+        Long commenterId,
+        String commenterNickname,
+        String content,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupReflectionCommentResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupReflectionCommentResponse.java
@@ -1,11 +1,13 @@
 package com.dnd5.timoapi.domain.group.presentation.response;
 
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import java.time.LocalDateTime;
 
 public record GroupReflectionCommentResponse(
         Long id,
         Long commenterId,
         String commenterNickname,
+        ZtpiCategory commenterCategory,
         String content,
         LocalDateTime createdAt
 ) {

--- a/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupTodayReflectionItem.java
+++ b/src/main/java/com/dnd5/timoapi/domain/group/presentation/response/GroupTodayReflectionItem.java
@@ -4,11 +4,13 @@ import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 
 public record GroupTodayReflectionItem(
         Long userId,
+        Long reflectionId,
         String nickname,
         ZtpiCategory userCategory,
         String questionContent,
         ZtpiCategory questionCategory,
         String answerText,
+        boolean isPublic,
         Integer streakDays,
         Integer totalDays
 ) {

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionQuestionService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionQuestionService.java
@@ -58,7 +58,7 @@ public class ReflectionQuestionService {
     @Transactional(readOnly = true)
     public ReflectionQuestionDetailResponse findById(Long questionId) {
         ReflectionQuestionEntity questionEntity = getQuestionEntity(questionId);
-        return ReflectionQuestionDetailResponse.from(questionEntity.toModel());
+        return ReflectionQuestionDetailResponse.from(questionEntity.toModel(), null, null);
     }
 
     public void update(Long questionId, ReflectionQuestionUpdateRequest request) {

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/application/service/ReflectionService.java
@@ -21,6 +21,7 @@ import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionQuesti
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionQuestionResponse;
 import com.dnd5.timoapi.domain.reflection.presentation.response.ReflectionResponse;
 import com.dnd5.timoapi.domain.customization.application.service.CustomizationItemService;
+import com.dnd5.timoapi.domain.customization.domain.model.CustomizationItemImage;
 import com.dnd5.timoapi.domain.customization.presentation.response.UnlockedCustomizationItemResponse;
 import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
@@ -89,7 +90,12 @@ public class ReflectionService {
     @Transactional(readOnly = true)
     public ReflectionQuestionDetailResponse findQuestionToday() {
         Long userId = SecurityUtil.getCurrentUserId();
-        return ReflectionQuestionDetailResponse.from(findTodayQuestionEntity(userId).toModel());
+        ReflectionQuestion question = findTodayQuestionEntity(userId).toModel();
+        CustomizationItemImage themeImage = customizationItemService.findEquippedThemeImage(userId, question.category());
+        return ReflectionQuestionDetailResponse.from(
+                question,
+                themeImage != null ? themeImage.image() : null,
+                themeImage != null ? themeImage.imageWithoutBackground() : null);
     }
 
     public ReflectionQuestionDetailResponse changeQuestionToday() {
@@ -140,7 +146,12 @@ public class ReflectionService {
 
         todayQuestionCacheService.incrementSkipCount(userId);
 
-        return ReflectionQuestionDetailResponse.from(newQuestion.toModel());
+        ReflectionQuestion questionModel = newQuestion.toModel();
+        CustomizationItemImage themeImage = customizationItemService.findEquippedThemeImage(userId, questionModel.category());
+        return ReflectionQuestionDetailResponse.from(
+                questionModel,
+                themeImage != null ? themeImage.image() : null,
+                themeImage != null ? themeImage.imageWithoutBackground() : null);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/dnd5/timoapi/domain/reflection/presentation/response/ReflectionQuestionDetailResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/reflection/presentation/response/ReflectionQuestionDetailResponse.java
@@ -11,10 +11,13 @@ public record ReflectionQuestionDetailResponse(
         String content,
         String createdBy,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+        String themeImage,
+        String themeImageWithoutBackground
 ) {
 
-    public static ReflectionQuestionDetailResponse from(ReflectionQuestion model) {
+    public static ReflectionQuestionDetailResponse from(
+            ReflectionQuestion model, String themeImage, String themeImageWithoutBackground) {
         return new ReflectionQuestionDetailResponse(
                 model.id(),
                 model.sequence(),
@@ -22,7 +25,9 @@ public record ReflectionQuestionDetailResponse(
                 model.content(),
                 model.createdBy(),
                 model.createdAt(),
-                model.updatedAt()
+                model.updatedAt(),
+                themeImage,
+                themeImageWithoutBackground
         );
     }
 }

--- a/src/main/java/com/dnd5/timoapi/domain/statistics/application/service/StatisticsService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/statistics/application/service/StatisticsService.java
@@ -53,20 +53,25 @@ public class StatisticsService {
                         dataPoints.add(new StatisticsScoreResponse(
                                 testResult.getScore(),
                                 testResult.getCreatedAt(),
-                                "TEST"
+                                "TEST",
+                                null,
+                                null
                         ));
                     }
 
                     List<ReflectionFeedbackEntity> categoryFeedbacks = feedbacksByCategory.getOrDefault(category, List.of());
                     categoryFeedbacks.stream()
                             .filter(fb -> fb.getAfterScore() != null)
-                            .forEach(fb ->
-                                    dataPoints.add(new StatisticsScoreResponse(
-                                            fb.getAfterScore(),
-                                            fb.getCreatedAt(),
-                                            "REFLECTION"
-                                    ))
-                            );
+                            .forEach(fb -> {
+                                ProximityInfo pointProximity = calculateProximity(fb, category.getIdealScore());
+                                dataPoints.add(new StatisticsScoreResponse(
+                                        fb.getAfterScore(),
+                                        fb.getCreatedAt(),
+                                        "REFLECTION",
+                                        pointProximity.proximityRate(),
+                                        pointProximity.isCloserToIdeal()
+                                ));
+                            });
 
                     ReflectionFeedbackEntity latestFeedback = categoryFeedbacks.isEmpty()
                             ? null : categoryFeedbacks.get(categoryFeedbacks.size() - 1);
@@ -102,6 +107,8 @@ public class StatisticsService {
                         testResult.getCreatedAt(),
                         "TEST",
                         null,
+                        null,
+                        null,
                         null
                 )));
 
@@ -110,13 +117,18 @@ public class StatisticsService {
 
         feedbacks.stream()
                 .filter(fb -> fb.getAfterScore() != null)
-                .forEach(fb -> dataPoints.add(new StatisticsScoreDetailResponse(
-                        fb.getAfterScore(),
-                        fb.getCreatedAt(),
-                        "REFLECTION",
-                        fb.getChangedScore(),
-                        fb.getIsIncreased()
-                )));
+                .forEach(fb -> {
+                    ProximityInfo pointProximity = calculateProximity(fb, category.getIdealScore());
+                    dataPoints.add(new StatisticsScoreDetailResponse(
+                            fb.getAfterScore(),
+                            fb.getCreatedAt(),
+                            "REFLECTION",
+                            fb.getChangedScore(),
+                            fb.getIsIncreased(),
+                            pointProximity.proximityRate(),
+                            pointProximity.isCloserToIdeal()
+                    ));
+                });
 
         ReflectionFeedbackEntity latestFeedback = feedbacks.isEmpty() ? null : feedbacks.get(feedbacks.size() - 1);
         ProximityInfo proximity = calculateProximity(latestFeedback, category.getIdealScore());

--- a/src/main/java/com/dnd5/timoapi/domain/statistics/application/service/StatisticsService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/statistics/application/service/StatisticsService.java
@@ -133,6 +133,9 @@ public class StatisticsService {
         );
     }
 
+    private static final double MIN_SCORE = 0;
+    private static final double MAX_SCORE = 5;
+
     private record ProximityInfo(Double changedScore, Double proximityRate, Boolean isCloserToIdeal) {}
 
     private ProximityInfo calculateProximity(ReflectionFeedbackEntity feedback, double idealScore) {
@@ -142,13 +145,11 @@ public class StatisticsService {
 
         double previousDistance = Math.abs(idealScore - feedback.getBeforeScore());
         double currentDistance = Math.abs(idealScore - feedback.getAfterScore());
+        double maxPossibleDistance = Math.max(idealScore - MIN_SCORE, MAX_SCORE - idealScore);
 
-        if (previousDistance == 0) {
-            return new ProximityInfo(feedback.getChangedScore(), null, null);
-        }
-
-        double proximityRate = Math.abs(previousDistance - currentDistance) / previousDistance * 100;
-        boolean isCloserToIdeal = currentDistance < previousDistance;
+        double changeRate = (previousDistance - currentDistance) / maxPossibleDistance * 100;
+        double proximityRate = Math.abs(changeRate);
+        boolean isCloserToIdeal = changeRate > 0;
 
         return new ProximityInfo(feedback.getChangedScore(), proximityRate, isCloserToIdeal);
     }

--- a/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/response/StatisticsScoreDetailResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/response/StatisticsScoreDetailResponse.java
@@ -7,7 +7,9 @@ public record StatisticsScoreDetailResponse(
         LocalDateTime createdAt,
         String type,
         Double changedScore,
-        Boolean isIncreased
+        Boolean isIncreased,
+        Double proximityRate,
+        Boolean isCloserToIdeal
 ) {
 
 }

--- a/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/response/StatisticsScoreResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/statistics/presentation/response/StatisticsScoreResponse.java
@@ -5,7 +5,9 @@ import java.time.LocalDateTime;
 public record StatisticsScoreResponse(
         double score,
         LocalDateTime createdAt,
-        String type
+        String type,
+        Double proximityRate,
+        Boolean isCloserToIdeal
 ) {
 
 }

--- a/src/main/java/com/dnd5/timoapi/domain/user/application/service/UserService.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/application/service/UserService.java
@@ -10,6 +10,8 @@ import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
 import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
 import com.dnd5.timoapi.domain.user.exception.UserErrorCode;
 import com.dnd5.timoapi.domain.user.presentation.request.UpdateMeRequest;
+import com.dnd5.timoapi.domain.user.presentation.response.AdminUserDetailResponse;
+import com.dnd5.timoapi.domain.user.presentation.response.AdminUserResponse;
 import com.dnd5.timoapi.domain.user.presentation.response.UserResponse;
 import com.dnd5.timoapi.global.exception.BusinessException;
 import com.dnd5.timoapi.global.security.context.SecurityUtil;
@@ -36,6 +38,22 @@ public class UserService {
         List<EquippedCustomizationResponse> equippedCustomizations =
                 customizationItemService.findEquippedItems(user.getId());
         return UserResponse.from(user.toModel(), equippedCustomizations);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdminUserResponse> findAllForAdmin() {
+        return userRepository.findAllByDeletedAtIsNull().stream()
+                .map(user -> AdminUserResponse.from(user.toModel()))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public AdminUserDetailResponse findByIdForAdmin(Long userId) {
+        UserEntity user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        List<EquippedCustomizationResponse> equippedCustomizations =
+                customizationItemService.findEquippedItems(user.getId());
+        return AdminUserDetailResponse.from(user.toModel(), equippedCustomizations);
     }
 
     public void updateMe(UpdateMeRequest request) {

--- a/src/main/java/com/dnd5/timoapi/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/domain/repository/UserRepository.java
@@ -15,6 +15,7 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByEmailAndDeletedAtIsNull(String email);
     boolean existsByEmailAndDeletedAtIsNull(String email);
     List<UserEntity> findAllByStreakDaysGreaterThanAndDeletedAtIsNull(Integer streakDays);
+    List<UserEntity> findAllByDeletedAtIsNull();
 
     @Modifying
     @Query("UPDATE UserEntity u SET u.streakDays = 0 WHERE u.streakDays > 0 AND u.deletedAt IS NULL AND u.id NOT IN :activeUserIds")

--- a/src/main/java/com/dnd5/timoapi/domain/user/presentation/AdminUserController.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/presentation/AdminUserController.java
@@ -1,0 +1,35 @@
+package com.dnd5.timoapi.domain.user.presentation;
+
+import com.dnd5.timoapi.domain.user.application.service.UserService;
+import com.dnd5.timoapi.domain.user.presentation.response.AdminUserDetailResponse;
+import com.dnd5.timoapi.domain.user.presentation.response.AdminUserResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/users")
+@RequiredArgsConstructor
+@Validated
+public class AdminUserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "전체 유저 목록 조회 (어드민)")
+    @GetMapping
+    public List<AdminUserResponse> getUsers() {
+        return userService.findAllForAdmin();
+    }
+
+    @Operation(summary = "유저 상세 조회 (어드민)")
+    @GetMapping("/{userId}")
+    public AdminUserDetailResponse getUser(@Positive @PathVariable Long userId) {
+        return userService.findByIdForAdmin(userId);
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/user/presentation/response/AdminUserDetailResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/presentation/response/AdminUserDetailResponse.java
@@ -1,0 +1,39 @@
+package com.dnd5.timoapi.domain.user.presentation.response;
+
+import com.dnd5.timoapi.domain.customization.presentation.response.EquippedCustomizationResponse;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+import com.dnd5.timoapi.domain.user.domain.model.User;
+import com.dnd5.timoapi.domain.user.domain.model.enums.OAuthProvider;
+import com.dnd5.timoapi.domain.user.domain.model.enums.UserRole;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AdminUserDetailResponse(
+        Long id,
+        String name,
+        String email,
+        OAuthProvider provider,
+        UserRole role,
+        ZtpiCategory category,
+        Boolean isOnboarded,
+        Integer streakDays,
+        Integer totalDays,
+        LocalDateTime createdAt,
+        List<EquippedCustomizationResponse> equippedCustomizations
+) {
+    public static AdminUserDetailResponse from(User model, List<EquippedCustomizationResponse> equippedCustomizations) {
+        return new AdminUserDetailResponse(
+                model.id(),
+                model.nickname(),
+                model.email(),
+                model.provider(),
+                model.role(),
+                model.category(),
+                model.isOnboarded(),
+                model.streakDays(),
+                model.totalDays(),
+                model.createdAt(),
+                equippedCustomizations
+        );
+    }
+}

--- a/src/main/java/com/dnd5/timoapi/domain/user/presentation/response/AdminUserResponse.java
+++ b/src/main/java/com/dnd5/timoapi/domain/user/presentation/response/AdminUserResponse.java
@@ -1,0 +1,30 @@
+package com.dnd5.timoapi.domain.user.presentation.response;
+
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
+import com.dnd5.timoapi.domain.user.domain.model.User;
+import com.dnd5.timoapi.domain.user.domain.model.enums.OAuthProvider;
+import java.time.LocalDateTime;
+
+public record AdminUserResponse(
+        Long id,
+        String name,
+        String email,
+        OAuthProvider provider,
+        ZtpiCategory category,
+        Integer streakDays,
+        Integer totalDays,
+        LocalDateTime createdAt
+) {
+    public static AdminUserResponse from(User model) {
+        return new AdminUserResponse(
+                model.id(),
+                model.nickname(),
+                model.email(),
+                model.provider(),
+                model.category(),
+                model.streakDays(),
+                model.totalDays(),
+                model.createdAt()
+        );
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -128,9 +128,9 @@ notification:
   swagger-diff:
     webhook-url: ${SWAGGER_DIFF_DISCORD_WEBHOOK_URL:}
   github-issue:
-    token: ${FRONTEND_GITHUB_TOKEN:}
-    owner: dnd-side-project
-    repo: dnd-14th-5-frontend
+    token: ${TIMO_GITHUB_TOKEN:}
+    owner: timo-side-project
+    repo: timo-frontend
 
 logstash:
   host: ${LOGSTASH_HOST:timo-logstash}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -129,8 +129,8 @@ notification:
     webhook-url: ${SWAGGER_DIFF_DISCORD_WEBHOOK_URL:}
   github-issue:
     token: ${TIMO_GITHUB_TOKEN:}
-    owner: timo-side-project
-    repo: timo-frontend
+    owner: ${TIMO_GITHUB_OWNER:timo-side-project}
+    repo: ${TIMO_GITHUB_FRONTEND_REPO:timo-frontend}
 
 logstash:
   host: ${LOGSTASH_HOST:timo-logstash}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -110,8 +110,8 @@ notification:
     webhook-url: ${SWAGGER_DIFF_DISCORD_WEBHOOK_URL:}
   github-issue:
     token: ${TIMO_GITHUB_TOKEN:}
-    owner: timo-side-project
-    repo: timo-frontend
+    owner: ${TIMO_GITHUB_OWNER:timo-side-project}
+    repo: ${TIMO_GITHUB_FRONTEND_REPO:timo-frontend}
 
 fcm:
   enabled: ${FCM_ENABLED:false}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -109,9 +109,9 @@ notification:
   swagger-diff:
     webhook-url: ${SWAGGER_DIFF_DISCORD_WEBHOOK_URL:}
   github-issue:
-    token: ${FRONTEND_GITHUB_TOKEN:}
-    owner: dnd-side-project
-    repo: dnd-14th-5-frontend
+    token: ${TIMO_GITHUB_TOKEN:}
+    owner: timo-side-project
+    repo: timo-frontend
 
 fcm:
   enabled: ${FCM_ENABLED:false}

--- a/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupReflectionCommentServiceTest.java
+++ b/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupReflectionCommentServiceTest.java
@@ -10,6 +10,7 @@ import com.dnd5.timoapi.domain.group.presentation.request.GroupReflectionComment
 import com.dnd5.timoapi.domain.group.presentation.response.GroupReflectionCommentResponse;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
+import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
 import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
 import com.dnd5.timoapi.global.exception.BusinessException;
@@ -147,6 +148,7 @@ class GroupReflectionCommentServiceTest {
         UserEntity commenter = mock(UserEntity.class);
         when(commenter.getId()).thenReturn(authorId);
         when(commenter.getNickname()).thenReturn("작성자닉네임");
+        when(commenter.getCategory()).thenReturn(ZtpiCategory.FUTURE);
         when(userRepository.findAllById(anyList())).thenReturn(List.of(commenter));
 
         try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
@@ -157,6 +159,7 @@ class GroupReflectionCommentServiceTest {
             assertThat(result).hasSize(1);
             assertThat(result.get(0).commenterId()).isEqualTo(authorId);
             assertThat(result.get(0).commenterNickname()).isEqualTo("작성자닉네임");
+            assertThat(result.get(0).commenterCategory()).isEqualTo(ZtpiCategory.FUTURE);
             assertThat(result.get(0).content()).isEqualTo("댓글 내용");
         }
     }

--- a/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupReflectionCommentServiceTest.java
+++ b/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupReflectionCommentServiceTest.java
@@ -1,0 +1,279 @@
+package com.dnd5.timoapi.domain.group.application.service;
+
+import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberEntity;
+import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberReflectionCommentEntity;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberReflectionCommentRepository;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberReflectionPrivateRepository;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberRepository;
+import com.dnd5.timoapi.domain.group.exception.GroupErrorCode;
+import com.dnd5.timoapi.domain.group.presentation.request.GroupReflectionCommentRequest;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupReflectionCommentResponse;
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
+import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
+import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
+import com.dnd5.timoapi.global.exception.BusinessException;
+import com.dnd5.timoapi.global.security.context.SecurityUtil;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GroupReflectionCommentServiceTest {
+
+    @InjectMocks
+    private GroupReflectionCommentService groupReflectionCommentService;
+
+    @Mock
+    private GroupMemberRepository groupMemberRepository;
+
+    @Mock
+    private ReflectionRepository reflectionRepository;
+
+    @Mock
+    private GroupMemberReflectionPrivateRepository groupMemberReflectionPrivateRepository;
+
+    @Mock
+    private GroupMemberReflectionCommentRepository groupMemberReflectionCommentRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    void create_성공() {
+        Long viewerId = 1L;
+        Long authorId = 2L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(true);
+
+        ReflectionEntity reflection = mock(ReflectionEntity.class);
+        when(reflection.getUserId()).thenReturn(authorId);
+        when(reflection.getDate()).thenReturn(LocalDate.of(2026, 8, 1));
+        when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflection));
+
+        GroupMemberEntity authorMember = mock(GroupMemberEntity.class);
+        when(authorMember.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 7, 1, 0, 0));
+        when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, authorId))
+                .thenReturn(Optional.of(authorMember));
+
+        when(groupMemberReflectionPrivateRepository.existsByGroupIdAndReflectionId(groupId, reflectionId)).thenReturn(false);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            groupReflectionCommentService.create(groupId, reflectionId, new GroupReflectionCommentRequest("좋은 회고네요"));
+
+            verify(groupMemberReflectionCommentRepository).save(any(GroupMemberReflectionCommentEntity.class));
+        }
+    }
+
+    @Test
+    void create_비공개_회고는_타인이_불가() {
+        Long viewerId = 1L;
+        Long authorId = 2L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(true);
+
+        ReflectionEntity reflection = mock(ReflectionEntity.class);
+        when(reflection.getUserId()).thenReturn(authorId);
+        when(reflection.getDate()).thenReturn(LocalDate.of(2026, 8, 1));
+        when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflection));
+
+        GroupMemberEntity authorMember = mock(GroupMemberEntity.class);
+        when(authorMember.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 7, 1, 0, 0));
+        when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, authorId))
+                .thenReturn(Optional.of(authorMember));
+
+        when(groupMemberReflectionPrivateRepository.existsByGroupIdAndReflectionId(groupId, reflectionId)).thenReturn(true);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            assertThatThrownBy(() -> groupReflectionCommentService.create(
+                    groupId, reflectionId, new GroupReflectionCommentRequest("내용")))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_ACCESS_DENIED));
+        }
+    }
+
+    @Test
+    void findAll_닉네임_포함해_반환() {
+        Long viewerId = 1L;
+        Long authorId = 2L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(true);
+
+        ReflectionEntity reflection = mock(ReflectionEntity.class);
+        when(reflection.getUserId()).thenReturn(authorId);
+        when(reflection.getDate()).thenReturn(LocalDate.of(2026, 8, 1));
+        when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflection));
+
+        GroupMemberEntity authorMember = mock(GroupMemberEntity.class);
+        when(authorMember.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 7, 1, 0, 0));
+        when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, authorId))
+                .thenReturn(Optional.of(authorMember));
+
+        when(groupMemberReflectionPrivateRepository.existsByGroupIdAndReflectionId(groupId, reflectionId)).thenReturn(false);
+
+        GroupMemberReflectionCommentEntity comment = mock(GroupMemberReflectionCommentEntity.class);
+        when(comment.getId()).thenReturn(500L);
+        when(comment.getUserId()).thenReturn(authorId);
+        when(comment.getContent()).thenReturn("댓글 내용");
+        when(comment.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 8, 2, 12, 0));
+        when(groupMemberReflectionCommentRepository
+                .findAllByGroupIdAndReflectionIdAndDeletedAtIsNullOrderByCreatedAtAsc(groupId, reflectionId))
+                .thenReturn(List.of(comment));
+
+        UserEntity commenter = mock(UserEntity.class);
+        when(commenter.getId()).thenReturn(authorId);
+        when(commenter.getNickname()).thenReturn("작성자닉네임");
+        when(userRepository.findAllById(anyList())).thenReturn(List.of(commenter));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            List<GroupReflectionCommentResponse> result = groupReflectionCommentService.findAll(groupId, reflectionId);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).commenterId()).isEqualTo(authorId);
+            assertThat(result.get(0).commenterNickname()).isEqualTo("작성자닉네임");
+            assertThat(result.get(0).content()).isEqualTo("댓글 내용");
+        }
+    }
+
+    @Test
+    void update_성공() {
+        Long userId = 1L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+        Long commentId = 500L;
+
+        GroupMemberReflectionCommentEntity comment = mock(GroupMemberReflectionCommentEntity.class);
+        when(comment.getUserId()).thenReturn(userId);
+        when(groupMemberReflectionCommentRepository
+                .findByIdAndGroupIdAndReflectionIdAndDeletedAtIsNull(commentId, groupId, reflectionId))
+                .thenReturn(Optional.of(comment));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            groupReflectionCommentService.update(
+                    groupId, reflectionId, commentId, new GroupReflectionCommentRequest("수정된 내용"));
+
+            verify(comment).update("수정된 내용");
+        }
+    }
+
+    @Test
+    void update_존재하지_않으면_404() {
+        Long userId = 1L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+        Long commentId = 500L;
+
+        when(groupMemberReflectionCommentRepository
+                .findByIdAndGroupIdAndReflectionIdAndDeletedAtIsNull(commentId, groupId, reflectionId))
+                .thenReturn(Optional.empty());
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            assertThatThrownBy(() -> groupReflectionCommentService.update(
+                    groupId, reflectionId, commentId, new GroupReflectionCommentRequest("내용")))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_REFLECTION_COMMENT_NOT_FOUND));
+        }
+    }
+
+    @Test
+    void update_작성자가_아니면_403() {
+        Long viewerId = 1L;
+        Long authorId = 2L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+        Long commentId = 500L;
+
+        GroupMemberReflectionCommentEntity comment = mock(GroupMemberReflectionCommentEntity.class);
+        when(comment.getUserId()).thenReturn(authorId);
+        when(groupMemberReflectionCommentRepository
+                .findByIdAndGroupIdAndReflectionIdAndDeletedAtIsNull(commentId, groupId, reflectionId))
+                .thenReturn(Optional.of(comment));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            assertThatThrownBy(() -> groupReflectionCommentService.update(
+                    groupId, reflectionId, commentId, new GroupReflectionCommentRequest("내용")))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_REFLECTION_COMMENT_NOT_OWNER));
+        }
+    }
+
+    @Test
+    void delete_성공_소프트딜리트() {
+        Long userId = 1L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+        Long commentId = 500L;
+
+        GroupMemberReflectionCommentEntity comment = mock(GroupMemberReflectionCommentEntity.class);
+        when(comment.getUserId()).thenReturn(userId);
+        when(groupMemberReflectionCommentRepository
+                .findByIdAndGroupIdAndReflectionIdAndDeletedAtIsNull(commentId, groupId, reflectionId))
+                .thenReturn(Optional.of(comment));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            groupReflectionCommentService.delete(groupId, reflectionId, commentId);
+
+            verify(comment).softDelete();
+        }
+    }
+
+    @Test
+    void delete_작성자가_아니면_403() {
+        Long viewerId = 1L;
+        Long authorId = 2L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+        Long commentId = 500L;
+
+        GroupMemberReflectionCommentEntity comment = mock(GroupMemberReflectionCommentEntity.class);
+        when(comment.getUserId()).thenReturn(authorId);
+        when(groupMemberReflectionCommentRepository
+                .findByIdAndGroupIdAndReflectionIdAndDeletedAtIsNull(commentId, groupId, reflectionId))
+                .thenReturn(Optional.of(comment));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            assertThatThrownBy(() -> groupReflectionCommentService.delete(groupId, reflectionId, commentId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_REFLECTION_COMMENT_NOT_OWNER));
+        }
+    }
+}

--- a/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupReflectionLikeServiceTest.java
+++ b/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupReflectionLikeServiceTest.java
@@ -1,0 +1,248 @@
+package com.dnd5.timoapi.domain.group.application.service;
+
+import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberEntity;
+import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberReflectionLikeEntity;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberReflectionLikeRepository;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberReflectionPrivateRepository;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberRepository;
+import com.dnd5.timoapi.domain.group.exception.GroupErrorCode;
+import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
+import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
+import com.dnd5.timoapi.domain.reflection.exception.ReflectionErrorCode;
+import com.dnd5.timoapi.global.exception.BusinessException;
+import com.dnd5.timoapi.global.security.context.SecurityUtil;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GroupReflectionLikeServiceTest {
+
+    @InjectMocks
+    private GroupReflectionLikeService groupReflectionLikeService;
+
+    @Mock
+    private GroupMemberRepository groupMemberRepository;
+
+    @Mock
+    private ReflectionRepository reflectionRepository;
+
+    @Mock
+    private GroupMemberReflectionPrivateRepository groupMemberReflectionPrivateRepository;
+
+    @Mock
+    private GroupMemberReflectionLikeRepository groupMemberReflectionLikeRepository;
+
+    @Test
+    void like_성공() {
+        Long viewerId = 1L;
+        Long authorId = 2L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(true);
+
+        ReflectionEntity reflection = mock(ReflectionEntity.class);
+        when(reflection.getUserId()).thenReturn(authorId);
+        when(reflection.getDate()).thenReturn(LocalDate.of(2026, 8, 1));
+        when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflection));
+
+        GroupMemberEntity authorMember = mock(GroupMemberEntity.class);
+        when(authorMember.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 7, 1, 0, 0));
+        when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, authorId))
+                .thenReturn(Optional.of(authorMember));
+
+        when(groupMemberReflectionPrivateRepository.existsByGroupIdAndReflectionId(groupId, reflectionId)).thenReturn(false);
+        when(groupMemberReflectionLikeRepository.existsByGroupIdAndReflectionIdAndUserId(groupId, reflectionId, viewerId))
+                .thenReturn(false);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            groupReflectionLikeService.like(groupId, reflectionId);
+
+            verify(groupMemberReflectionLikeRepository).save(any(GroupMemberReflectionLikeEntity.class));
+        }
+    }
+
+    @Test
+    void like_비멤버_403() {
+        Long viewerId = 1L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(false);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            assertThatThrownBy(() -> groupReflectionLikeService.like(groupId, reflectionId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_ACCESS_DENIED));
+        }
+    }
+
+    @Test
+    void like_비공개_회고는_타인이_불가() {
+        Long viewerId = 1L;
+        Long authorId = 2L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(true);
+
+        ReflectionEntity reflection = mock(ReflectionEntity.class);
+        when(reflection.getUserId()).thenReturn(authorId);
+        when(reflection.getDate()).thenReturn(LocalDate.of(2026, 8, 1));
+        when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflection));
+
+        GroupMemberEntity authorMember = mock(GroupMemberEntity.class);
+        when(authorMember.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 7, 1, 0, 0));
+        when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, authorId))
+                .thenReturn(Optional.of(authorMember));
+
+        when(groupMemberReflectionPrivateRepository.existsByGroupIdAndReflectionId(groupId, reflectionId)).thenReturn(true);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            assertThatThrownBy(() -> groupReflectionLikeService.like(groupId, reflectionId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_ACCESS_DENIED));
+        }
+    }
+
+    @Test
+    void like_이미_좋아요면_409() {
+        Long viewerId = 1L;
+        Long authorId = 2L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(true);
+
+        ReflectionEntity reflection = mock(ReflectionEntity.class);
+        when(reflection.getUserId()).thenReturn(authorId);
+        when(reflection.getDate()).thenReturn(LocalDate.of(2026, 8, 1));
+        when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflection));
+
+        GroupMemberEntity authorMember = mock(GroupMemberEntity.class);
+        when(authorMember.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 7, 1, 0, 0));
+        when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, authorId))
+                .thenReturn(Optional.of(authorMember));
+
+        when(groupMemberReflectionPrivateRepository.existsByGroupIdAndReflectionId(groupId, reflectionId)).thenReturn(false);
+        when(groupMemberReflectionLikeRepository.existsByGroupIdAndReflectionIdAndUserId(groupId, reflectionId, viewerId))
+                .thenReturn(true);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            assertThatThrownBy(() -> groupReflectionLikeService.like(groupId, reflectionId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_REFLECTION_LIKE_ALREADY_EXISTS));
+        }
+    }
+
+    @Test
+    void like_작성자_그룹_가입일_이전_회고면_404() {
+        Long viewerId = 1L;
+        Long authorId = 2L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(true);
+
+        ReflectionEntity reflection = mock(ReflectionEntity.class);
+        when(reflection.getUserId()).thenReturn(authorId);
+        when(reflection.getDate()).thenReturn(LocalDate.of(2026, 6, 1));
+        when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflection));
+
+        GroupMemberEntity authorMember = mock(GroupMemberEntity.class);
+        when(authorMember.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 7, 1, 0, 0));
+        when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, authorId))
+                .thenReturn(Optional.of(authorMember));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            assertThatThrownBy(() -> groupReflectionLikeService.like(groupId, reflectionId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReflectionErrorCode.REFLECTION_NOT_FOUND));
+        }
+    }
+
+    @Test
+    void unlike_성공() {
+        Long viewerId = 1L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(true);
+
+        GroupMemberReflectionLikeEntity like = mock(GroupMemberReflectionLikeEntity.class);
+        when(groupMemberReflectionLikeRepository.findByGroupIdAndReflectionIdAndUserId(groupId, reflectionId, viewerId))
+                .thenReturn(Optional.of(like));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            groupReflectionLikeService.unlike(groupId, reflectionId);
+
+            verify(groupMemberReflectionLikeRepository).delete(like);
+        }
+    }
+
+    @Test
+    void unlike_비멤버_403() {
+        Long viewerId = 1L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(false);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            assertThatThrownBy(() -> groupReflectionLikeService.unlike(groupId, reflectionId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_ACCESS_DENIED));
+        }
+    }
+
+    @Test
+    void unlike_좋아요_없으면_404() {
+        Long viewerId = 1L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(true);
+        when(groupMemberReflectionLikeRepository.findByGroupIdAndReflectionIdAndUserId(groupId, reflectionId, viewerId))
+                .thenReturn(Optional.empty());
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            assertThatThrownBy(() -> groupReflectionLikeService.unlike(groupId, reflectionId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_REFLECTION_LIKE_NOT_FOUND));
+        }
+    }
+}

--- a/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupServiceTest.java
+++ b/src/test/java/com/dnd5/timoapi/domain/group/application/service/GroupServiceTest.java
@@ -5,19 +5,27 @@ import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberEntity;
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupMemberRole;
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupType;
 import com.dnd5.timoapi.domain.group.domain.model.enums.GroupReflectionSort;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberReflectionCommentRepository;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberReflectionLikeRepository;
+import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberReflectionPrivateRepository;
 import com.dnd5.timoapi.domain.group.domain.repository.GroupMemberRepository;
 import com.dnd5.timoapi.domain.group.domain.repository.GroupRepository;
 import com.dnd5.timoapi.domain.group.exception.GroupErrorCode;
 import com.dnd5.timoapi.domain.group.presentation.request.GroupCreateRequest;
 import com.dnd5.timoapi.domain.group.presentation.request.GroupUpdateRequest;
+import com.dnd5.timoapi.domain.group.domain.entity.GroupMemberReflectionPrivateEntity;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupCreateResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupDetailResponse;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupMemberReflectionDetailResponse;
+import com.dnd5.timoapi.domain.group.presentation.response.GroupMemberReflectionResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupResponse;
 import com.dnd5.timoapi.domain.group.presentation.response.GroupTodayReflectionItem;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionEntity;
 import com.dnd5.timoapi.domain.reflection.domain.entity.ReflectionQuestionEntity;
+import com.dnd5.timoapi.domain.reflection.domain.model.ReflectionQuestion;
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionQuestionRepository;
 import com.dnd5.timoapi.domain.reflection.domain.repository.ReflectionRepository;
+import com.dnd5.timoapi.domain.reflection.exception.ReflectionErrorCode;
 import com.dnd5.timoapi.domain.test.domain.model.enums.ZtpiCategory;
 import com.dnd5.timoapi.domain.user.domain.entity.UserEntity;
 import com.dnd5.timoapi.domain.user.domain.repository.UserRepository;
@@ -32,6 +40,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -60,6 +69,15 @@ class GroupServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private GroupMemberReflectionPrivateRepository groupMemberReflectionPrivateRepository;
+
+    @Mock
+    private GroupMemberReflectionLikeRepository groupMemberReflectionLikeRepository;
+
+    @Mock
+    private GroupMemberReflectionCommentRepository groupMemberReflectionCommentRepository;
 
     @Test
     void createGroup_FRIEND_성공_코드_자동_생성() {
@@ -550,6 +568,376 @@ class GroupServiceTest {
             assertThat(withReflection.answerText()).isEqualTo("회고 내용");
             assertThat(withoutReflection.answerText()).isNull();
             assertThat(withoutReflection.questionContent()).isNull();
+        }
+    }
+
+    @Test
+    void getTodayReflections_FRIEND_비공개_회고는_타인에게_content_null() {
+        Long viewerId = 99L;
+        Long groupId = 10L;
+        Long authorId = 1L;
+        Long reflectionId = 500L;
+
+        GroupEntity groupEntity = mock(GroupEntity.class);
+        when(groupEntity.getType()).thenReturn(GroupType.FRIEND);
+        when(groupRepository.findByIdAndDeletedAtIsNull(groupId)).thenReturn(Optional.of(groupEntity));
+
+        GroupMemberEntity member = mock(GroupMemberEntity.class);
+        when(member.getUserId()).thenReturn(authorId);
+        when(groupMemberRepository.findAllByGroupIdAndDeletedAtIsNull(groupId)).thenReturn(List.of(member));
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(true);
+
+        ReflectionEntity reflection = mock(ReflectionEntity.class);
+        when(reflection.getId()).thenReturn(reflectionId);
+        when(reflection.getUserId()).thenReturn(authorId);
+        when(reflection.getQuestionId()).thenReturn(100L);
+        when(reflectionRepository.findAllByDateAndUserIdIn(any(LocalDate.class), anyList()))
+                .thenReturn(List.of(reflection));
+
+        ReflectionQuestionEntity question = mock(ReflectionQuestionEntity.class);
+        when(question.getId()).thenReturn(100L);
+        when(question.getContent()).thenReturn("오늘의 질문");
+        when(question.getCategory()).thenReturn(ZtpiCategory.FUTURE);
+        when(reflectionQuestionRepository.findAllById(anyList())).thenReturn(List.of(question));
+
+        UserEntity user = mock(UserEntity.class);
+        when(user.getId()).thenReturn(authorId);
+        when(user.getNickname()).thenReturn("작성자");
+        when(user.getStreakDays()).thenReturn(1);
+        when(user.getTotalDays()).thenReturn(1);
+        when(userRepository.findAllById(anyList())).thenReturn(List.of(user));
+
+        GroupMemberReflectionPrivateEntity privateEntity = mock(GroupMemberReflectionPrivateEntity.class);
+        when(privateEntity.getReflectionId()).thenReturn(reflectionId);
+        when(groupMemberReflectionPrivateRepository.findAllByGroupIdAndReflectionIdIn(eq(groupId), anyList()))
+                .thenReturn(List.of(privateEntity));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            List<GroupTodayReflectionItem> result = groupService.getTodayReflections(groupId, GroupReflectionSort.LATEST);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).reflectionId()).isEqualTo(reflectionId);
+            assertThat(result.get(0).isPublic()).isFalse();
+            assertThat(result.get(0).answerText()).isNull();
+        }
+    }
+
+    @Test
+    void getMemberReflection_공개_회고는_타인도_content_조회_가능() {
+        Long viewerId = 1L;
+        Long authorId = 2L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(true);
+
+        ReflectionEntity reflection = mock(ReflectionEntity.class);
+        when(reflection.getId()).thenReturn(reflectionId);
+        when(reflection.getUserId()).thenReturn(authorId);
+        when(reflection.getQuestionId()).thenReturn(200L);
+        when(reflection.getAnswerText()).thenReturn("공개 회고 내용");
+        when(reflection.getDate()).thenReturn(LocalDate.of(2026, 8, 1));
+        when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflection));
+
+        GroupMemberEntity authorMember = mock(GroupMemberEntity.class);
+        when(authorMember.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 7, 1, 0, 0));
+        when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, authorId))
+                .thenReturn(Optional.of(authorMember));
+
+        ReflectionQuestionEntity question = mock(ReflectionQuestionEntity.class);
+        when(question.toModel()).thenReturn(
+                new ReflectionQuestion(200L, 1L, ZtpiCategory.FUTURE, "질문", "admin", null, null));
+        when(reflectionQuestionRepository.findById(200L)).thenReturn(Optional.of(question));
+
+        when(groupMemberReflectionPrivateRepository.existsByGroupIdAndReflectionId(groupId, reflectionId)).thenReturn(false);
+        when(groupMemberReflectionLikeRepository.countByGroupIdAndReflectionId(groupId, reflectionId)).thenReturn(3L);
+        when(groupMemberReflectionCommentRepository.countByGroupIdAndReflectionIdAndDeletedAtIsNull(groupId, reflectionId))
+                .thenReturn(2L);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            GroupMemberReflectionDetailResponse response = groupService.getMemberReflection(groupId, reflectionId);
+
+            assertThat(response.content()).isEqualTo("공개 회고 내용");
+            assertThat(response.likes()).isEqualTo(3L);
+            assertThat(response.comments()).isEqualTo(2L);
+        }
+    }
+
+    @Test
+    void getMemberReflection_비공개_회고는_타인에게_content_null() {
+        Long viewerId = 1L;
+        Long authorId = 2L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(true);
+
+        ReflectionEntity reflection = mock(ReflectionEntity.class);
+        when(reflection.getId()).thenReturn(reflectionId);
+        when(reflection.getUserId()).thenReturn(authorId);
+        when(reflection.getQuestionId()).thenReturn(200L);
+        when(reflection.getDate()).thenReturn(LocalDate.of(2026, 8, 1));
+        when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflection));
+
+        GroupMemberEntity authorMember = mock(GroupMemberEntity.class);
+        when(authorMember.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 7, 1, 0, 0));
+        when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, authorId))
+                .thenReturn(Optional.of(authorMember));
+
+        ReflectionQuestionEntity question = mock(ReflectionQuestionEntity.class);
+        when(question.toModel()).thenReturn(
+                new ReflectionQuestion(200L, 1L, ZtpiCategory.FUTURE, "질문", "admin", null, null));
+        when(reflectionQuestionRepository.findById(200L)).thenReturn(Optional.of(question));
+
+        when(groupMemberReflectionPrivateRepository.existsByGroupIdAndReflectionId(groupId, reflectionId)).thenReturn(true);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            GroupMemberReflectionDetailResponse response = groupService.getMemberReflection(groupId, reflectionId);
+
+            assertThat(response.content()).isNull();
+        }
+    }
+
+    @Test
+    void getMemberReflection_본인_비공개_회고는_content_노출() {
+        Long userId = 2L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)).thenReturn(true);
+
+        ReflectionEntity reflection = mock(ReflectionEntity.class);
+        when(reflection.getId()).thenReturn(reflectionId);
+        when(reflection.getUserId()).thenReturn(userId);
+        when(reflection.getQuestionId()).thenReturn(200L);
+        when(reflection.getAnswerText()).thenReturn("내 비공개 회고");
+        when(reflection.getDate()).thenReturn(LocalDate.of(2026, 8, 1));
+        when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflection));
+
+        GroupMemberEntity authorMember = mock(GroupMemberEntity.class);
+        when(authorMember.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 7, 1, 0, 0));
+        when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId))
+                .thenReturn(Optional.of(authorMember));
+
+        ReflectionQuestionEntity question = mock(ReflectionQuestionEntity.class);
+        when(question.toModel()).thenReturn(
+                new ReflectionQuestion(200L, 1L, ZtpiCategory.FUTURE, "질문", "admin", null, null));
+        when(reflectionQuestionRepository.findById(200L)).thenReturn(Optional.of(question));
+
+        when(groupMemberReflectionPrivateRepository.existsByGroupIdAndReflectionId(groupId, reflectionId)).thenReturn(true);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            GroupMemberReflectionDetailResponse response = groupService.getMemberReflection(groupId, reflectionId);
+
+            assertThat(response.content()).isEqualTo("내 비공개 회고");
+        }
+    }
+
+    @Test
+    void getMemberReflection_비멤버_조회시_403() {
+        Long viewerId = 1L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(false);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            assertThatThrownBy(() -> groupService.getMemberReflection(groupId, reflectionId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_ACCESS_DENIED));
+        }
+    }
+
+    @Test
+    void getMemberReflection_존재하지_않는_회고면_404() {
+        Long viewerId = 1L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(true);
+        when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.empty());
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            assertThatThrownBy(() -> groupService.getMemberReflection(groupId, reflectionId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReflectionErrorCode.REFLECTION_NOT_FOUND));
+        }
+    }
+
+    @Test
+    void getMemberReflection_작성자_그룹_가입일_이전_회고면_404() {
+        Long viewerId = 1L;
+        Long authorId = 2L;
+        Long groupId = 10L;
+        Long reflectionId = 100L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(true);
+
+        ReflectionEntity reflection = mock(ReflectionEntity.class);
+        when(reflection.getUserId()).thenReturn(authorId);
+        when(reflection.getDate()).thenReturn(LocalDate.of(2026, 6, 1));
+        when(reflectionRepository.findById(reflectionId)).thenReturn(Optional.of(reflection));
+
+        GroupMemberEntity authorMember = mock(GroupMemberEntity.class);
+        when(authorMember.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 7, 1, 0, 0));
+        when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, authorId))
+                .thenReturn(Optional.of(authorMember));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            assertThatThrownBy(() -> groupService.getMemberReflection(groupId, reflectionId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReflectionErrorCode.REFLECTION_NOT_FOUND));
+        }
+    }
+
+    @Test
+    void getMemberCalendar_가입일_이후_회고만_비공개_마스킹해_반환() {
+        Long viewerId = 1L;
+        Long targetUserId = 2L;
+        Long groupId = 10L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(true);
+
+        GroupMemberEntity targetMember = mock(GroupMemberEntity.class);
+        when(targetMember.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 7, 1, 0, 0));
+        when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, targetUserId))
+                .thenReturn(Optional.of(targetMember));
+
+        ReflectionEntity publicReflection = mock(ReflectionEntity.class);
+        when(publicReflection.getId()).thenReturn(1L);
+        when(publicReflection.getQuestionId()).thenReturn(200L);
+        when(publicReflection.getAnswerText()).thenReturn("공개 회고");
+        when(publicReflection.getDate()).thenReturn(LocalDate.of(2026, 7, 5));
+
+        ReflectionEntity privateReflection = mock(ReflectionEntity.class);
+        when(privateReflection.getId()).thenReturn(2L);
+        when(privateReflection.getQuestionId()).thenReturn(200L);
+        when(privateReflection.getDate()).thenReturn(LocalDate.of(2026, 7, 6));
+
+        when(reflectionRepository.findAllByUserIdAndDateBetween(eq(targetUserId), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(List.of(publicReflection, privateReflection));
+
+        ReflectionQuestionEntity question = mock(ReflectionQuestionEntity.class);
+        when(question.getId()).thenReturn(200L);
+        when(question.toModel()).thenReturn(
+                new ReflectionQuestion(200L, 1L, ZtpiCategory.FUTURE, "질문", "admin", null, null));
+        when(reflectionQuestionRepository.findAllById(anyList())).thenReturn(List.of(question));
+
+        GroupMemberReflectionPrivateEntity privateEntity = mock(GroupMemberReflectionPrivateEntity.class);
+        when(privateEntity.getReflectionId()).thenReturn(2L);
+        when(groupMemberReflectionPrivateRepository.findAllByGroupIdAndReflectionIdIn(eq(groupId), anyList()))
+                .thenReturn(List.of(privateEntity));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            List<GroupMemberReflectionResponse> result = groupService.getMemberCalendar(groupId, targetUserId);
+
+            assertThat(result).hasSize(2);
+            GroupMemberReflectionResponse publicItem = result.stream().filter(r -> r.id().equals(1L)).findFirst().orElseThrow();
+            GroupMemberReflectionResponse privateItem = result.stream().filter(r -> r.id().equals(2L)).findFirst().orElseThrow();
+            assertThat(publicItem.isPublic()).isTrue();
+            assertThat(publicItem.content()).isEqualTo("공개 회고");
+            assertThat(privateItem.isPublic()).isFalse();
+            assertThat(privateItem.content()).isNull();
+        }
+    }
+
+    @Test
+    void getMemberCalendar_본인_캘린더면_비공개도_content_노출() {
+        Long userId = 2L;
+        Long groupId = 10L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId)).thenReturn(true);
+
+        GroupMemberEntity targetMember = mock(GroupMemberEntity.class);
+        when(targetMember.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 7, 1, 0, 0));
+        when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, userId))
+                .thenReturn(Optional.of(targetMember));
+
+        ReflectionEntity privateReflection = mock(ReflectionEntity.class);
+        when(privateReflection.getId()).thenReturn(2L);
+        when(privateReflection.getQuestionId()).thenReturn(200L);
+        when(privateReflection.getAnswerText()).thenReturn("내 비공개 회고");
+        when(privateReflection.getDate()).thenReturn(LocalDate.of(2026, 7, 6));
+
+        when(reflectionRepository.findAllByUserIdAndDateBetween(eq(userId), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(List.of(privateReflection));
+
+        ReflectionQuestionEntity question = mock(ReflectionQuestionEntity.class);
+        when(question.getId()).thenReturn(200L);
+        when(question.toModel()).thenReturn(
+                new ReflectionQuestion(200L, 1L, ZtpiCategory.FUTURE, "질문", "admin", null, null));
+        when(reflectionQuestionRepository.findAllById(anyList())).thenReturn(List.of(question));
+
+        GroupMemberReflectionPrivateEntity privateEntity = mock(GroupMemberReflectionPrivateEntity.class);
+        when(privateEntity.getReflectionId()).thenReturn(2L);
+        when(groupMemberReflectionPrivateRepository.findAllByGroupIdAndReflectionIdIn(eq(groupId), anyList()))
+                .thenReturn(List.of(privateEntity));
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            List<GroupMemberReflectionResponse> result = groupService.getMemberCalendar(groupId, userId);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).isPublic()).isFalse();
+            assertThat(result.get(0).content()).isEqualTo("내 비공개 회고");
+        }
+    }
+
+    @Test
+    void getMemberCalendar_대상_유저가_그룹_멤버가_아니면_404() {
+        Long viewerId = 1L;
+        Long targetUserId = 2L;
+        Long groupId = 10L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(true);
+        when(groupMemberRepository.findByGroupIdAndUserIdAndDeletedAtIsNull(groupId, targetUserId))
+                .thenReturn(Optional.empty());
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            assertThatThrownBy(() -> groupService.getMemberCalendar(groupId, targetUserId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_MEMBER_NOT_FOUND));
+        }
+    }
+
+    @Test
+    void getMemberCalendar_뷰어가_비멤버면_403() {
+        Long viewerId = 1L;
+        Long targetUserId = 2L;
+        Long groupId = 10L;
+
+        when(groupMemberRepository.existsByGroupIdAndUserIdAndDeletedAtIsNull(groupId, viewerId)).thenReturn(false);
+
+        try (MockedStatic<SecurityUtil> mocked = Mockito.mockStatic(SecurityUtil.class)) {
+            mocked.when(SecurityUtil::getCurrentUserId).thenReturn(viewerId);
+
+            assertThatThrownBy(() -> groupService.getMemberCalendar(groupId, targetUserId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(GroupErrorCode.GROUP_ACCESS_DENIED));
         }
     }
 }


### PR DESCRIPTION
## What is this PR? :mag:
- 그룹 멤버 회고 캘린더(월별 이력) 및 상세 조회 API 추가
- 오늘의 그룹 회고 목록에 reflectionId, isPublic 반영 및 비공개 컨텐츠 마스킹 적용
- 좋아요/댓글/비공개 설정용 테이블 3종 스키마 선반영 (CRUD는 후속 브랜치)
- 그룹 가입일 이전 회고는 그룹 컨텍스트에서 노출되지 않도록 접근 제어 추가

## Changes :memo:

**API 추가**
- GET /groups/{groupId}/reflections/{reflectionId} — 그룹 멤버 회고 상세 조회 (질문, 답변, 좋아요/댓글 개수)
- GET /groups/{groupId}/members/{userId}/calendar — 그룹 멤버 회고 캘린더(월별 이력) 조회

**API 변경**
- GET /groups/{groupId}/reflections/today 응답에 reflectionId, isPublic 추가 + 비공개 회고는 answerText null 처리

**DB 설계**
- 3개 신규 테이블 추가
- user_group_member_reflection_privates — row 존재 = 비공개 (컬럼 없이 존재 여부로 판단, 하드 딜리트)
- user_group_member_reflection_likes — 좋아요 (하드 딜리트, user_id 통일)
- user_group_member_reflection_comments — 댓글 (소프트 딜리트, user_id 통일)
  - 이번 브랜치에선 스키마만 선반영, CRUD는 2·3번 브랜치에서 구현 예정

**접근 제어 관련**
- 뷰어가 그룹 멤버 아니면 403
- 그룹 가입일 이전에 쓴 회고는 그룹 내에서 조회 불가(404)
- 비공개 회고는 본인 제외 content null 처리 (feedback은 애초에 그룹 응답에서 제외)

**테스트**
GroupServiceTest에 11개 케이스 추가, 전체 테스트 통과 (기존부터 실패 중인 contextLoads 무관 이슈 제외)

---
### Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 저장소에 공개되면 안 되는 파일이 커밋되진 않았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin tools to view user lists and detailed user information.
  * Added group member reflection details and calendar views.
  * Added likes and comments for group reflections.
  * Added reflection privacy controls that hide private content from non-owners.
  * Today’s reflections now include visibility information and reflection IDs.
  * Reflection questions can display equipped theme images.
  * Statistics now show proximity to category ideals and improvement indicators.

* **Bug Fixes**
  * Improved handling when no equipped theme image is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->